### PR TITLE
QTextElement - small fix when reusing text cells.

### DIFF
--- a/quickdialog/QTextElement.m
+++ b/quickdialog/QTextElement.m
@@ -35,13 +35,14 @@
     if (cell==nil){
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"QuickfromTextElement"];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    
-        cell.textLabel.font = _font;
-        cell.textLabel.lineBreakMode = UILineBreakModeWordWrap;
-        cell.textLabel.numberOfLines = 0;
-        cell.textLabel.textColor = _color;
-        cell.textLabel.text = _text;
     }
+
+    cell.textLabel.font = _font;
+    cell.textLabel.lineBreakMode = UILineBreakModeWordWrap;
+    cell.textLabel.numberOfLines = 0;
+    cell.textLabel.textColor = _color;
+    cell.textLabel.text = _text;
+
     return cell;
 }
 


### PR DESCRIPTION
QTextElement: fixed error when reusing QTextElement cells  when reusing
QTextElement cells, text and other properties are not set in all times.
