### PR TITLE
Renamed setObject:forKey: to setValue:forKey: in QRadioElement

### DIFF
--- a/quickdialog/QRadioElement.m
+++ b/quickdialog/QRadioElement.m
@@ -82,9 +82,9 @@
         return;
 
     if (_values==nil){
-        [obj setObject:[NSNumber numberWithInt:_selected] forKey:_key];
+        [obj setValue:[NSNumber numberWithInt:_selected] forKey:_key];
     } else {
-        [obj setObject:[_values objectAtIndex:(NSUInteger) _selected] forKey:_key];
+        [obj setValue:[_values objectAtIndex:(NSUInteger) _selected] forKey:_key];
     }
 }
 


### PR DESCRIPTION
Hello again,

I was having some issues using fetchValueIntoObject: with a QRadioElement. I traced the issue to these two method calls – changing them made everything work as I expected.

Let me know if you have any questions.

Really enjoying QuickDialog so far, thanks for all of your work!

Ezra
