### PR TITLE
QTextElement will only call onSelected if not NULL

### DIFF
--- a/quickdialog/QTextElement.m
+++ b/quickdialog/QTextElement.m
@@ -48,7 +48,10 @@
 }
 
 - (void)selected:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller indexPath:(NSIndexPath *)indexPath {
-    self.onSelected();
+    if (self.onSelected) {
+        self.onSelected();
+    }
+    
 }
 
 - (CGFloat)getRowHeightForTableView:(QuickDialogTableView *)tableView {


### PR DESCRIPTION
(otherwise it would cause a crash)
