### PR TITLE
Custom height support

### DIFF
--- a/quickdialog/QElement.h
+++ b/quickdialog/QElement.h
@@ -21,6 +21,8 @@
 @protected
     __weak QSection *_parentSection;
     NSString *_key;
+	
+	CGFloat _height;
 
     void (^_onSelected)(void);
     NSString * _controllerAction;
@@ -30,6 +32,7 @@
 @property(nonatomic, copy) void (^onSelected)(void);
 @property(nonatomic, retain) NSString *controllerAction;
 
+@property(nonatomic) CGFloat height;
 
 @property(nonatomic, weak) QSection *parentSection;
 

--- a/quickdialog/QElement.m
+++ b/quickdialog/QElement.m
@@ -24,7 +24,7 @@
 @synthesize onSelected = _onSelected;
 @synthesize controllerAction = _controllerAction;
 @synthesize object = _object;
-
+@synthesize height = _height;
 
 - (QElement *)initWithKey:(NSString *)key {
     self = [super init];
@@ -59,7 +59,7 @@
 }
 
 - (CGFloat)getRowHeightForTableView:(QuickDialogTableView *)tableView {
-    return 44;
+    return _height > 44 ? _height : 44;
 }
 
 - (void)fetchValueIntoObject:(id)obj {

--- a/quickdialog/QTextElement.m
+++ b/quickdialog/QTextElement.m
@@ -61,7 +61,8 @@
     }
     CGSize constraint = CGSizeMake(300, 20000);
     CGSize  size= [_text sizeWithFont:_font constrainedToSize:constraint lineBreakMode:UILineBreakModeWordWrap];
-    return size.height+20;
+	CGFloat predictedHeight = size.height + 20.0f;
+	return (_height >= predictedHeight) ? _height : predictedHeight;
 }
 
 - (void)fetchValueIntoObject:(id)obj {


### PR DESCRIPTION
QuickDialog uses the iOS default of 44px for a table view cell's height, sometimes you want to use a more spacious one - see countless apps like Twitter (push notification and account settings), Settings, etc. If you don't set it or it's set less than 44 (that'd be ugly), we force the default of 44. If it's a text box, the same applies except the calculated height value is used instead of 44.
