### PR TITLE
Forward UITextfield Delegate

### DIFF
--- a/quickdialog/QDecimalTableViewCell.m
+++ b/quickdialog/QDecimalTableViewCell.m
@@ -81,8 +81,8 @@
     [self updateElementFromTextField:newValue];
     [self updateTextFieldFromElement];
     
-    if(self.delegate && [self.delegate respondsToSelector:@selector(textField:shouldChangeCharactersInRange:replacementString::)]){
-        [self.delegate textField:textField shouldChangeCharactersInRange:range replacementString:replacement];
+    if(_entryElement && self.delegate && [self.delegate respondsToSelector:@selector(QEntryTableViewCellShouldChangeCharactersInRange:)]){
+        [self.delegate QEntryTableViewCellShouldChangeCharactersInRange:_entryElement];
     }
     
     return NO;

--- a/quickdialog/QEntryTableViewCell.h
+++ b/quickdialog/QEntryTableViewCell.h
@@ -15,15 +15,17 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@class QEntryTableViewCell;
+
 @protocol ForwardedUITextFieldDelegate <NSObject>
 
 @optional
-- (void)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string;
-- (void)textField:(UITextField *)textField editingChanged:(QEntryElement *)element;
-- (void)textField:(UITextField *)textField didBeginEditing:(QEntryElement *)element;
-- (void)textField:(UITextField *)textField didEndEditing:(QEntryElement *)element;
-- (void)textField:(UITextField *)textField shouldReturn:(QEntryElement *)element;
-- (void)textField:(UITextField *)textField mustReturn:(QEntryElement *)element;
+- (void)QEntryTableViewCellShouldChangeCharactersInRange:(QEntryElement *)element;
+- (void)QEntryTableViewCellEditingChanged:(QEntryElement *)element;
+- (void)QEntryTableViewCellDidBeginEditing:(QEntryElement *)element;
+- (void)QEntryTableViewCellDidEndEditing:(QEntryElement *)element;
+- (void)QEntryTableViewCellShouldReturn:(QEntryElement *)element;
+- (void)QEntryTableViewCellMustReturn:(QEntryElement *)element;
 
 @end
 

--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -136,8 +136,8 @@
 - (void)textFieldEditingChanged:(UITextField *)textFieldEditingChanged {
    _entryElement.textValue = _textField.text;
     
-    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(textField:editingChanged:)]){
-        [_delegate textField:textFieldEditingChanged editingChanged:_entryElement];
+    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(QEntryTableViewCellEditingChanged:)]){
+        [_delegate QEntryTableViewCellEditingChanged:_entryElement];
     }
 }
 
@@ -148,8 +148,8 @@
     }
     _quickformTableView.selectedCell = self;
     
-    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(textField:didBeginEditing:)]){
-        [_delegate textField:textField didBeginEditing:_entryElement];
+    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(QEntryTableViewCellDidBeginEditing:)]){
+        [_delegate QEntryTableViewCellDidBeginEditing:_entryElement];
     }
 }
 
@@ -163,8 +163,8 @@
 - (void)textFieldDidEndEditing:(UITextField *)textField {
     _entryElement.textValue = _textField.text;
     
-    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(textField:didEndEditing:)]){
-        [_delegate textField:textField didEndEditing:_entryElement];
+    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(QEntryTableViewCellDidEndEditing:)]){
+        [_delegate QEntryTableViewCellDidEndEditing:_entryElement];
     }
 }
 
@@ -179,8 +179,8 @@
         }
     }
     
-    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(textField:shouldReturn:)]){
-        [_delegate textField:textField shouldReturn:_entryElement];
+    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(QEntryTableViewCellShouldReturn:)]){
+        [_delegate QEntryTableViewCellShouldReturn:_entryElement];
     }
     
     return YES;
@@ -209,8 +209,8 @@
 - (BOOL)textFieldMustReturn:(UITextField *)textField {
     [_textField resignFirstResponder];
     
-    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(textField:mustReturn:)]){
-        [_delegate textField:textField mustReturn:_entryElement];
+    if(_entryElement && _delegate && [_delegate respondsToSelector:@selector(QEntryTableViewCellMustReturn:)]){
+        [_delegate QEntryTableViewCellMustReturn:_entryElement];
     }
     
     return NO;


### PR DESCRIPTION
I have added an optional delegate to QEntryTableViewCell called "ForwardedUITextFieldDelegate" this enhancement will allow controllers other than QEntryTableViewCell to respond to UITextfield delegate methods.  An example where this may prove useful is performing an action when the "Done" button on they keyboard is clicked.  In the sample the LoginController could respond to the delegate method 

```
- (void)textField:(UITextField *)textField shouldReturn:(QEntryElement *)element {
    if([element.key isEqualToString:@"password"]) {
        [self onSignIn:element];
    }
}
```

the textField parameter might prove to be irrelevant with the addition of the QEntryElement as a parameter, but I was trying to keep this delegate somewhat close to the UITextfield delegate.  I added a forward delegate method for each of the delegate methods that are being used by QEntryTableViewCell, there are a few additional delegate that could be added but these might not be relevant in the context of QuickDialog.  
