### PR TITLE
QuickDialogTableView as a subview

### DIFF
--- a/quickdialog/QButtonElement.m
+++ b/quickdialog/QButtonElement.m
@@ -30,6 +30,7 @@
         cell= [[QTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"QuickformButtonElement"];
     }
     cell.selectionStyle = UITableViewCellSelectionStyleBlue;
+    cell.imageView.image = _image;
     cell.textLabel.text = _title;
     cell.textLabel.textAlignment = UITextAlignmentCenter;
     cell.textLabel.textColor = [UIColor colorWithRed:50.0f/255.0f green:79.0f/255.0f blue:133.0f/255.0f alpha:1];

--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -62,7 +62,16 @@
 - (void)loadView {
     [super loadView];
     self.quickDialogTableView = [[QuickDialogTableView alloc] initWithController:self];
-    self.view = self.quickDialogTableView;
+    //self.view = self.quickDialogTableView;
+    self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.view.autoresizesSubviews = YES;
+    self.view.contentMode = UIViewContentModeRedraw;
+    self.view.frame = CGRectMake(0.0f, 0.0f, 480.0f, 480.0f);
+    
+    self.quickDialogTableView.frame = self.view.frame;
+    
+    [self.view addSubview:self.quickDialogTableView];
+    
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation


### PR DESCRIPTION
I made a slight change to your QuickDialogController in order to add the table view as a subview. This allows me to set a background image without the horrible tiling effect associated with grouped tables.

The change did not break the sample application, so I assume it's safe to include, but you might want to run a few more tests.
