### PR TITLE
fixing date entry bugs

### DIFF
--- a/quickdialog/QDateEntryTableViewCell.m
+++ b/quickdialog/QDateEntryTableViewCell.m
@@ -37,7 +37,7 @@
 
     _pickerView = [[UIDatePicker alloc] init];
     [_pickerView sizeToFit];
-    _pickerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
+//    _pickerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     [_pickerView addTarget:self action:@selector(dateChanged:)
               forControlEvents:UIControlEventValueChanged];
 

--- a/quickdialog/QDateTimeInlineElement.m
+++ b/quickdialog/QDateTimeInlineElement.m
@@ -64,7 +64,7 @@
         cell = [[QDateEntryTableViewCell alloc] init];
     }
     [cell prepareForElement:self inTableView:tableView];
-    cell.selectionStyle = UITableViewCellSelectionStyleBlue ;
+    cell.selectionStyle = UITableViewCellSelectionStyleNone ;
     return cell;
 
 }


### PR DESCRIPTION
fixing floating date entry selector on iPad and removing blue selection style from datetime fields.  fixes #75
