### PR TITLE
Added method to QPickerValueParser to parse object into displayable string

### DIFF
--- a/QuickDialog.xcodeproj/project.pbxproj
+++ b/QuickDialog.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		D8F180E813F0599A009B0CD0 /* jsonremote.json in Resources */ = {isa = PBXBuildFile; fileRef = D8F180E813F0599A009B0CCF /* jsonremote.json */; };
 		D8F180E813F0599A009B0CD2 /* QuickDialogWebController.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F180E813F0599A009B0CD1 /* QuickDialogWebController.m */; };
 		D8F180E813F0599A009B0CD4 /* QuickDialogWebController.h in Headers */ = {isa = PBXBuildFile; fileRef = D8F180E813F0599A009B0CD3 /* QuickDialogWebController.h */; };
+		F209CEE41536AB100043F61C /* PeriodPickerValueParser.m in Sources */ = {isa = PBXBuildFile; fileRef = F209CEE31536AB100043F61C /* PeriodPickerValueParser.m */; };
 		F2E6149E151C9E4D00F36976 /* QSelectSection.h in Headers */ = {isa = PBXBuildFile; fileRef = F2E6149C151C9E4D00F36976 /* QSelectSection.h */; };
 		F2E6149F151C9E4D00F36976 /* QSelectSection.m in Sources */ = {isa = PBXBuildFile; fileRef = F2E6149D151C9E4D00F36976 /* QSelectSection.m */; };
 		F2E614A2151CA1A100F36976 /* QSelectItemElement.h in Headers */ = {isa = PBXBuildFile; fileRef = F2E614A0151CA1A100F36976 /* QSelectItemElement.h */; };
@@ -313,6 +314,8 @@
 		D8F180E813F0599A009B0CCF /* jsonremote.json */ = {isa = PBXFileReference; lastKnownFileType = file.json; name = jsonremote.json; path = sample/Resources/jsonremote.json; sourceTree = SOURCE_ROOT; };
 		D8F180E813F0599A009B0CD1 /* QuickDialogWebController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QuickDialogWebController.m; path = quickdialog/QuickDialogWebController.m; sourceTree = SOURCE_ROOT; };
 		D8F180E813F0599A009B0CD3 /* QuickDialogWebController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QuickDialogWebController.h; path = quickdialog/QuickDialogWebController.h; sourceTree = SOURCE_ROOT; };
+		F209CEE21536AB100043F61C /* PeriodPickerValueParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PeriodPickerValueParser.h; path = sample/PeriodPickerValueParser.h; sourceTree = SOURCE_ROOT; };
+		F209CEE31536AB100043F61C /* PeriodPickerValueParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PeriodPickerValueParser.m; path = sample/PeriodPickerValueParser.m; sourceTree = SOURCE_ROOT; };
 		F2E6149C151C9E4D00F36976 /* QSelectSection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QSelectSection.h; path = quickdialog/QSelectSection.h; sourceTree = SOURCE_ROOT; };
 		F2E6149D151C9E4D00F36976 /* QSelectSection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QSelectSection.m; path = quickdialog/QSelectSection.m; sourceTree = SOURCE_ROOT; };
 		F2E614A0151CA1A100F36976 /* QSelectItemElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QSelectItemElement.h; path = quickdialog/QSelectItemElement.h; sourceTree = SOURCE_ROOT; };
@@ -411,6 +414,8 @@
 				D811F8EC13EC907200E3922B /* ExampleAppDelegate.m */,
 				D811F8ED13EC907200E3922B /* ExampleViewController.h */,
 				D811F8EE13EC907200E3922B /* ExampleViewController.m */,
+				F209CEE21536AB100043F61C /* PeriodPickerValueParser.h */,
+				F209CEE31536AB100043F61C /* PeriodPickerValueParser.m */,
 				D811F8EF13EC907200E3922B /* Resources */,
 				D80B0E3E13E052DF00FA85CA /* Supporting Files */,
 			);
@@ -835,6 +840,7 @@
 				D811F90213EC907200E3922B /* ExampleAppDelegate.m in Sources */,
 				D811F90313EC907200E3922B /* ExampleViewController.m in Sources */,
 				D8F180E813F0599A009B0CAC /* JsonDataSampleController.m in Sources */,
+				F209CEE41536AB100043F61C /* PeriodPickerValueParser.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/quickdialog/QPickerElement.h
+++ b/quickdialog/QPickerElement.h
@@ -13,6 +13,6 @@
 
 @property(nonatomic, strong) NSArray *items;
 
-- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items value:(NSString *)value;
+- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items value:(id)value;
 
 @end

--- a/quickdialog/QPickerElement.m
+++ b/quickdialog/QPickerElement.m
@@ -13,13 +13,13 @@
 @synthesize valueParser = _valueParser;
 @synthesize onValueChanged = _onValueChanged;
 
--(QPickerElement *)init {
+- (QPickerElement *)init {
     self = [super init];
     self.valueParser = [QPickerWhitespaceDelimitedStringParser new];
     return self;
 }
 
-- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items value:(NSString *)value
+- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items value:(id)value
 {
     if ((self = [super initWithTitle:title Value:value])) {
         _items = items;

--- a/quickdialog/QPickerTableViewCell.m
+++ b/quickdialog/QPickerTableViewCell.m
@@ -70,8 +70,14 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
     
     QPickerElement *pickerElement = (QPickerElement *)element;
 
-    self.detailTextLabel.text = [pickerElement.value description];
-	self.textField.text = [pickerElement.value description];
+    if ([pickerElement.valueParser respondsToSelector:@selector(presentationOfObject:)]) {
+        self.detailTextLabel.text = [pickerElement.valueParser presentationOfObject:pickerElement.value];
+        _textField.text = [pickerElement.valueParser presentationOfObject:pickerElement.valueParser];
+    } else {
+        self.detailTextLabel.text = [pickerElement.value description];
+        _textField.text = [pickerElement.value description];
+    }
+    
     [self setNeedsDisplay];
 }
 

--- a/quickdialog/QPickerValueParser.h
+++ b/quickdialog/QPickerValueParser.h
@@ -13,4 +13,7 @@
 - (id)objectFromComponentsValues:(NSArray *)componentsValues;
 - (NSArray *)componentsValuesFromObject:(id)object;
 
+@optional
+- (NSString *)presentationOfObject:(id)object;
+
 @end

--- a/sample/PeriodPickerValueParser.h
+++ b/sample/PeriodPickerValueParser.h
@@ -1,0 +1,15 @@
+//
+//  AMPeriodPickerValueParser.h
+//  AutoMobile
+//
+//  Created by HiveHicks on 11.04.12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface PeriodPickerValueParser : NSObject <QPickerValueParser>
+
+@property (nonatomic, readonly) NSArray *stringPeriods;
+
+@end

--- a/sample/PeriodPickerValueParser.m
+++ b/sample/PeriodPickerValueParser.m
@@ -1,0 +1,56 @@
+//
+//  AMPeriodPickerValueParser.m
+//  AutoMobile
+//
+//  Created by HiveHicks on 11.04.12.
+//  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
+//
+
+#import "PeriodPickerValueParser.h"
+
+@implementation PeriodPickerValueParser {
+    NSDictionary *valuesMap;
+}
+
+- (id)init
+{
+    if (self = [super init])
+    {
+        valuesMap =
+            [NSDictionary dictionaryWithObjectsAndKeys:
+             @"daily",      [NSNumber numberWithUnsignedInteger:NSDayCalendarUnit],
+             @"weekly",     [NSNumber numberWithUnsignedInteger:NSWeekCalendarUnit],
+             @"monthly",    [NSNumber numberWithUnsignedInteger:NSMonthCalendarUnit],
+             @"yearly",     [NSNumber numberWithUnsignedInteger:NSYearCalendarUnit], nil];
+    }
+    
+    return self;
+}
+
+- (NSArray *)stringPeriods
+{
+    return [valuesMap allValues];
+}
+
+- (id)objectFromComponentsValues:(NSArray *)componentsValues
+{
+    NSString *stringPeriod = [componentsValues objectAtIndex:0];
+    for (NSNumber *calendarUnitWrapper in valuesMap) {
+        if ([[valuesMap objectForKey:calendarUnitWrapper] isEqualToString:stringPeriod]) {
+            return calendarUnitWrapper;
+        }
+    }
+    return nil;
+}
+
+- (NSArray *)componentsValuesFromObject:(id)object
+{
+    return [NSArray arrayWithObject:[valuesMap objectForKey:object]];
+}
+
+- (NSString *)presentationOfObject:(id)object
+{
+    return [valuesMap objectForKey:object];
+}
+
+@end

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -15,6 +15,7 @@
 #import <objc/runtime.h>
 #import "SampleDataBuilder.h"
 #import "QDynamicDataSection.h"
+#import "PeriodPickerValueParser.h"
 
 @implementation SampleDataBuilder
 
@@ -272,7 +273,7 @@
     root.title = @"Picker";
     root.grouped = YES;
     
-    QSection *section = [[QSection alloc] initWithTitle:@"Picker element"];
+    QSection *simplePickerSection = [[QSection alloc] initWithTitle:@"Picker element"];
     
     NSMutableArray *component1 = [NSMutableArray array];
     for (int i = 1; i <= 12; i++) {
@@ -281,10 +282,25 @@
     
     NSArray *component2 = [NSArray arrayWithObjects:@"A", @"B", nil];
     
-    [section addElement:[[QPickerElement alloc] initWithTitle:@"Key"
+    [simplePickerSection addElement:[[QPickerElement alloc] initWithTitle:@"Key"
                                             items:[NSArray arrayWithObjects:component1, component2, nil]
                                                         value:nil]];
-    [root addSection:section];
+    [root addSection:simplePickerSection];
+    
+    QSection *customParserSection = [[QSection alloc] initWithTitle:@"Custom value parser"];
+    
+    PeriodPickerValueParser *periodParser = [[PeriodPickerValueParser alloc] init];
+    
+    QPickerElement *periodPickerEl =
+        [[QPickerElement alloc] initWithTitle:@"Period"
+                                        items:[NSArray arrayWithObject:periodParser.stringPeriods]
+                                        value:[NSNumber numberWithUnsignedInteger:NSMonthCalendarUnit]];
+    
+    periodPickerEl.valueParser = periodParser;
+    periodPickerEl.onValueChanged = ^{ NSLog(@"New value: %@", periodPickerEl.value); };
+    
+    [customParserSection addElement:periodPickerEl];
+    [root addSection:customParserSection];
     
     return root;
 }


### PR DESCRIPTION
Actually QPickerValueParser should manage 3 aspects of picker:
1. Values in components
2. How these values work together to form an object
3. How that object is displayed in cell
This commit brings the latter to the QPickerValueParser protocol.
