### PR TITLE
Reused cell bug fix

### DIFF
--- a/quickdialog/QElement.m
+++ b/quickdialog/QElement.m
@@ -50,6 +50,11 @@
     if (cell == nil){
         cell = [[QTableViewCell alloc] initWithReuseIdentifier:[NSString stringWithFormat:@"QuickformElementCell%@", self.key]];
     }
+
+    cell.textLabel.text = nil; 
+    cell.detailTextLabel.text = nil; 
+    cell.imageView.image = nil; 
+
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.showsReorderControl = YES;
     cell.accessoryView = nil;


### PR DESCRIPTION
I've noticed this bug when some elements had detailLabel, and some (root section for example) did not, but labels stayed.
Just common reused cell bug =)
