### PR TITLE
Fix in QBadgeElement

### DIFF
--- a/quickdialog/QBadgeElement.m
+++ b/quickdialog/QBadgeElement.m
@@ -43,6 +43,7 @@
     cell.badgeLabel.text = _badge;
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
+    cell.imageView.image = _image;
     cell.accessoryType = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
     cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
     return cell;


### PR DESCRIPTION
When using QBadgeElement to implement a similar functionality as QLabelElement, noticed that the image wasn't rendering. Added the code to render the image within the getCellForTableView method in QBadgeElement.m.
