### PR TITLE
Fix for QLabelElement cell accessorytype bug which caused user-set accessory type to be ignored

### DIFF
--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -50,7 +50,7 @@
     cell.textLabel.text = _title;
     cell.detailTextLabel.text = [_value description];
     cell.imageView.image = _image;
-    cell.accessoryType = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
+    cell.accessoryType = self.sections!= nil || self.controllerAction!=nil ? (_accessoryType != (int) nil ? _accessoryType : UITableViewCellAccessoryDisclosureIndicator) : UITableViewCellAccessoryNone;
     cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
 
     return cell;


### PR DESCRIPTION
There was a small bug in QLabelElement which effectively meant that any accessory type set by the user was always replaced with `UITableViewCellAccessoryDisclosureIndicator`.
