### PR TITLE
Fixed setting the color property on QTextElement

### DIFF
--- a/quickdialog/QTextElement.m
+++ b/quickdialog/QTextElement.m
@@ -47,9 +47,7 @@
     cell.textLabel.adjustsFontSizeToFitWidth = YES;
     cell.textLabel.text = self.title;
     cell.detailTextLabel.font = _font;
-    if([cell.detailTextLabel respondsToSelector:@selector(textColor:)]) {
-            cell.detailTextLabel.textColor = _color;
-    }
+    cell.detailTextLabel.textColor = _color;
     cell.detailTextLabel.text = _text;
     
     return cell;


### PR DESCRIPTION
``` objective-c
QTextElement *element = [[QTextElement alloc] initWithText:@"Lorem ipsum dolor sit amet"];
element.font = [UIFont boldSystemFontOfSize:16];
element.color = [UIColor blackColor];
```

Setting the color didn't work. Removed the `respondsToSelector` check, as `detailTextLabel.textColor` can always be set.
