### PR TITLE
Selection style option for QLabelElement

### DIFF
--- a/quickdialog/QLabelElement.h
+++ b/quickdialog/QLabelElement.h
@@ -27,6 +27,7 @@
 @property(nonatomic, strong) UIImage *image;
 @property(nonatomic, assign) NSString *imageNamed;
 @property(nonatomic, assign) UITableViewCellAccessoryType accessoryType;
+@property(nonatomic, assign) UITableViewCellSelectionStyle selectionStyle;
 @property(nonatomic, strong) id value;
 
 

--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -18,12 +18,14 @@
 @implementation QLabelElement {
 @private
     UITableViewCellAccessoryType _accessoryType;
+    UITableViewCellSelectionStyle _selectionStyle;
 }
 
 
 @synthesize image = _image;
 @synthesize value = _value;
 @synthesize accessoryType = _accessoryType;
+@synthesize selectionStyle = _selectionStyle;
 
 
 - (QLabelElement *)initWithTitle:(NSString *)title Value:(id)value {
@@ -51,7 +53,7 @@
     cell.detailTextLabel.text = [_value description];
     cell.imageView.image = _image;
     cell.accessoryType = self.sections!= nil || self.controllerAction!=nil ? (_accessoryType != (int) nil ? _accessoryType : UITableViewCellAccessoryDisclosureIndicator) : UITableViewCellAccessoryNone;
-    cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
+    cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil || self.selectionStyle != (int) nil ? (_selectionStyle != (int)nil ? _selectionStyle : UITableViewCellSelectionStyleBlue) : UITableViewCellSelectionStyleNone;
 
     return cell;
 }


### PR DESCRIPTION
Not sure if this change is something that you're particularly interested in grabbing, but basically I ran into a situation where I needed to show a selection style but had to use onSelected rather than setting a controllerAction, so I added a selection style option to QLabelElement. This is also kind of useful if you want to set the label to have a gray selection style.
