### PR TITLE
Fixes issue with reusing QEntryElement cell after a QRadioElement has used it.

### DIFF
--- a/quickdialog/QEntryElement.m
+++ b/quickdialog/QEntryElement.m
@@ -50,7 +50,9 @@
     if (cell==nil){
         cell = [[QEntryTableViewCell alloc] init];
     }
+    cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textField.enabled = YES;
+    cell.textField.userInteractionEnabled = YES;
     cell.imageView.image = self.image;
     [cell prepareForElement:self inTableView:tableView];
     return cell;


### PR DESCRIPTION
QRadioElement was setting the selection style and disabling user interaction with
the Cell's text field.  If the cell was reused for a QEntryElement further down
a form, it would retain these traits. This change fixes this.
