### PR TITLE
Moved cell:willAppearForElement:atIndexPath: call to QuickDialogTableDelegate

### DIFF
--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -31,11 +31,8 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     QSection *section = [_tableView.root getSectionForIndex:indexPath.section];
-    QElement * element = [section.elements objectAtIndex:(NSUInteger) indexPath.row];
+    QElement *element = [section.elements objectAtIndex:(NSUInteger) indexPath.row];
     UITableViewCell *cell = [element getCellForTableView:(QuickDialogTableView *) tableView controller:_tableView.controller];
-    if (_tableView.styleProvider!=nil){
-        [_tableView.styleProvider cell:cell willAppearForElement:element atIndexPath:indexPath];
-    }
     return cell;
 }
 

--- a/quickdialog/QuickDialogTableDelegate.m
+++ b/quickdialog/QuickDialogTableDelegate.m
@@ -122,6 +122,14 @@
     return section.footer != NULL? stringFooterHeight : 0;
 }
 
+- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath {
+    QSection *section = [_tableView.root getSectionForIndex:indexPath.section];
+    QElement *element = [section.elements objectAtIndex:(NSUInteger) indexPath.row];
+    if (_tableView.styleProvider != nil) {
+        [_tableView.styleProvider cell:cell willAppearForElement:element atIndexPath:indexPath];
+    }
+}
+
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)index {
     QSection *section = [_tableView.root getSectionForIndex:index];
 


### PR DESCRIPTION
In my project a had an issue: I changed cell color in `cell:willAppearForElement:atIndexPath:` delegate method, but it didn't work. I've dived into QuickDialog source code and fond out that its called in table data source's `tableView:cellForRowAtIndexPath:` method. Due to some experience with settings cells' background I know that such operations should better be made in table DELEGATE's `tableView:willDisplayCell:forRowAtIndexPath:`. So I moved this method call to delegate - and now everything works.
