### PR TITLE
Fixing behaviour of QBooleanElement to be consistent

### DIFF
--- a/quickdialog/QBooleanElement.m
+++ b/quickdialog/QBooleanElement.m
@@ -68,32 +68,23 @@
     return cell;
 }
 
-- (void)selected:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller indexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView cellForRowAtIndexPath:indexPath];
-    self.boolValue = !self.boolValue;
-    if ([cell.accessoryView class] == [UIImageView class]){
-        ((UIImageView *)cell.accessoryView).image =  self.boolValue ? _onImage : _offImage;
-    }
-    if (self.controllerAction==nil)
-        [tableView deselectRowAtIndexPath:indexPath animated:YES];
-    [self handleElementSelected:controller];
-}
-
-- (void)handleChange {
-    if ((_controller != nil && self.controllerAction != nil) || _onSelected != nil) {
-        [self handleElementSelected:_controller];
-    }
+- (void)selected:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller indexPath:(NSIndexPath *)path {
+    ;
 }
 
 - (void)buttonPressed:(UIButton *)boolButton {
     self.boolValue = !boolButton.selected;
     boolButton.selected = _boolValue;
-    [self handleChange];
+    if ((_controller != nil && self.controllerAction != nil) || _onSelected != nil) {
+        [self handleElementSelected:_controller];
+    }
 }
 
 - (void)switched:(id)boolSwitch {
     self.boolValue = ((UISwitch *)boolSwitch).on;
-    [self handleChange];
+    if ((_controller != nil && self.controllerAction != nil) || _onSelected != nil) {
+        [self handleElementSelected:_controller];
+    }
 }
 
 - (void)fetchValueIntoObject:(id)obj {

--- a/sample/ExampleViewController.m
+++ b/sample/ExampleViewController.m
@@ -43,6 +43,10 @@
 
 }
 
+- (void) handleCheckbox:(QBooleanElement *)booleanElement {
+    NSLog(@"New bool value: %d", [booleanElement boolValue]);
+}
+
 -(void)exampleAction:(QElement *)element{
     UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Hey!" message:@"This is the exampleAction method in the ExampleViewController" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
     [alert show];

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -76,6 +76,7 @@
         QBooleanElement *bool1 = [[QBooleanElement alloc] initWithTitle:[NSString stringWithFormat:@"Option %d", i] BoolValue:(i % 3 == 0)];
         bool1.onImage = [UIImage imageNamed:@"imgOn"];
         bool1.offImage = [UIImage imageNamed:@"imgOff"];
+        bool1.controllerAction = @"handleCheckbox:";
         [subsection addElement:bool1];
     }
     [subForm addSection:subsection];


### PR DESCRIPTION
Ok, this one is ok.
As stated in #200 this pull request is for making a consistent behaviour for QBooleanElement so using either way of displaying value results in the same handlers being called.

To do so, selection handler is disabled (as I don't see a point on handle the selection on a QBooleanElement) and value changes handler uses controllerAction or onSelected as it was done previously only for switch style QBooleanElements.
