### PR TITLE
Enable left image views on QWebElement and QMapElement (good one)

### DIFF
--- a/quickdialog/QMapElement.h
+++ b/quickdialog/QMapElement.h
@@ -14,11 +14,10 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+#import "QLabelElement.h"
 
-@class QRootElement;
 
-
-@interface QMapElement : QRootElement {
+@interface QMapElement : QLabelElement {
 
 @protected
     CLLocationCoordinate2D _coordinate;

--- a/quickdialog/QMapElement.m
+++ b/quickdialog/QMapElement.m
@@ -39,6 +39,12 @@
     _coordinate.longitude = lng;
 }
 
+- (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {
+    UITableViewCell *cell = [super getCellForTableView:tableView controller:controller];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    return cell;
+}
+
 - (void)selected:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller indexPath:(NSIndexPath *)path {
     QMapViewController *mapController = [[QMapViewController alloc] initWithTitle:_title coordinate:_coordinate];
     [controller displayViewController:mapController];

--- a/quickdialog/QWebElement.h
+++ b/quickdialog/QWebElement.h
@@ -13,9 +13,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "QRootElement.h"
+#import "QLabelElement.h"
 
-@interface QWebElement : QRootElement {
+@interface QWebElement : QLabelElement {
 
 @protected
     NSString *_url;

--- a/quickdialog/QWebElement.m
+++ b/quickdialog/QWebElement.m
@@ -26,6 +26,11 @@
     return self;
 }
 
+- (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {
+    UITableViewCell *cell = [super getCellForTableView:tableView controller:controller];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    return cell;
+}
 
 - (void)selected:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller indexPath:(NSIndexPath *)path {
     [self handleElementSelected:controller];

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -341,12 +341,17 @@
 
     QWebElement *element1 = [[QWebElement alloc] initWithTitle:@"ESCOZ Inc" url:@"http://escoz.com"];
     element1.controllerAction = @"handleWebElementControllerAction:";
+    element1.image = [UIImage imageNamed:@"iPhone"];
     QWebElement *element2 = [[QWebElement alloc] initWithTitle:@"Quicklytics" url:@"http://escoz.com/quicklytics"];
+    QMapElement *element3 = [[QMapElement alloc] initWithTitle:@"Florianopolis, Brazil" coordinate:CLLocationCoordinate2DMake(-27.59, -48.55)];
+    element3.image = [UIImage imageNamed:@"keyboard"];
     QMapElement *element4 = [[QMapElement alloc] initWithTitle:@"Florianopolis, Brazil" coordinate:CLLocationCoordinate2DMake(-27.59, -48.55)];
+
 
     QSection *section1 = [[QSection alloc] init];
     [section1 addElement:element1];
     [section1 addElement:element2];
+    [section1 addElement:element3];
     [section1 addElement:element4];
 
     [root addSection:section1];


### PR DESCRIPTION
Sorry for the dupe again, multiple pull request are not easy.

Almost every other element of QDialog inherits from QLabelElement and thus has the capability of showing images except this two (maybe there are more I have missed) so changed the inheritance and fixed the accesory view to mantain the old style (not sure if it was a feature).
