### PR TITLE
Avoid reusing button cells with key

### DIFF
--- a/quickdialog/QButtonElement.m
+++ b/quickdialog/QButtonElement.m
@@ -30,10 +30,10 @@
 }
 
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"QuickformButtonElement"];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:[NSString stringWithFormat:@"QuickformButtonElement%@", self.key]];
     if (cell == nil){
-        cell= [[QTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:@"QuickformButtonElement"];
-    }
+        cell = [[QTableViewCell alloc] initWithReuseIdentifier:[NSString stringWithFormat:@"QuickformButtonElement%@", self.key]];
+    }    
     if (self.enabled) {
         cell.selectionStyle = UITableViewCellSelectionStyleBlue;
         cell.textLabel.textColor = [UIColor colorWithRed:50.0f/255.0f green:79.0f/255.0f blue:133.0f/255.0f alpha:1];    


### PR DESCRIPTION
It seems that change 7303ad59 in QElement.m was not migrated to the same function on QButtonElement and thus reusing buttons does not take into account the key for special buttons with custom layout or design.
