### PR TITLE
Issue #196 - Fixes QDateTimeElement multiple initializeRoot calls bug.

### DIFF
--- a/quickdialog/QDateTimeElement.m
+++ b/quickdialog/QDateTimeElement.m
@@ -123,7 +123,6 @@
         timeElement.hiddenToolbar = YES;
         [section addElement:timeElement];
     }
-    [[self sections] removeAllObjects];
     [self addSection:section];
 }
 


### PR DESCRIPTION
QDateTimeElement's `initWithTitle:date:` initialisation method calls `[self init]`, which calls `[self initializeRoot]`, but `initWithTitle` calls it again after setting the title and date.

To fix it, I initially cleared the sections array in initializeRoot, but this is kind of unnecessary. The elements just need to be updated since they are already created and initialised during init. So I added an updateElements method, which grabs the QDateTimeInlineElements by key and updates their dateValue to the correct value.

(Addresses issue #196).
