### PR TITLE
QBooleanElement: Fix for selected method toggling boolValue but not switch/button element

### DIFF
--- a/quickdialog/QBooleanElement.m
+++ b/quickdialog/QBooleanElement.m
@@ -74,6 +74,9 @@
     if ([cell.accessoryView class] == [UIButton class]) {
         ((UIButton *)cell.accessoryView).selected = self.boolValue;
     }
+    else if ([cell.accessoryView class] == [UISwitch class]) {
+        [((UISwitch *)cell.accessoryView) setOn:self.boolValue animated:YES];
+    }
 
     if (self.controllerAction==nil)
         [tableView deselectRowAtIndexPath:indexPath animated:YES];


### PR DESCRIPTION
There is an issue I came across with QBooleanElement where when selecting the cell containing the UIButton or UISwitch, the element's boolean value is toggled, but the image or switch is never updated, making it out of sync and fairly unpredictable.

This pull request fixes this by toggling the UIButton or UISwitch (in the UISwitch case, with animation).
