### PR TITLE
Added textAlignment property for QEntryElement

### DIFF
--- a/quickdialog/QEntryElement.h
+++ b/quickdialog/QEntryElement.h
@@ -34,6 +34,7 @@
 
 @property(nonatomic) UITextAutocapitalizationType autocapitalizationType; // default is UITextAutocapitalizationTypeSentences
 @property(nonatomic) UITextAutocorrectionType autocorrectionType;         // default is UITextAutocorrectionTypeDefault
+@property(nonatomic) UITextAlignment textAlignment;                       // default is UITextAlignmentLeft
 @property(nonatomic) UIKeyboardType keyboardType;                         // default is UIKeyboardTypeDefault
 @property(nonatomic) UIKeyboardAppearance keyboardAppearance;             // default is UIKeyboardAppearanceDefault
 @property(nonatomic) UIReturnKeyType returnKeyType;                       // default is UIReturnKeyDefault (See note under UIReturnKeyType enum)

--- a/quickdialog/QEntryElement.m
+++ b/quickdialog/QEntryElement.m
@@ -27,6 +27,7 @@
     if (self){
         self.autocapitalizationType = UITextAutocapitalizationTypeSentences;
         self.autocorrectionType = UITextAutocorrectionTypeDefault;
+        self.textAlignment = UITextAlignmentLeft;
         self.keyboardType = UIKeyboardTypeDefault;
         self.keyboardAppearance = UIKeyboardAppearanceDefault;
         self.returnKeyType = UIReturnKeyDefault;
@@ -55,6 +56,7 @@
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textField.enabled = YES;
     cell.textField.userInteractionEnabled = YES;
+    cell.textField.textAlignment = self.textAlignment;
     cell.imageView.image = self.image;
     [cell prepareForElement:self inTableView:tableView];
     return cell;
@@ -80,6 +82,7 @@
 
 @synthesize autocorrectionType = _autocorrectionType;
 @synthesize autocapitalizationType = _autocapitalizationType;
+@synthesize textAlignment = _textAlignment;
 @synthesize keyboardType = _keyboardType;
 @synthesize keyboardAppearance = _keyboardAppearance;
 @synthesize returnKeyType = _returnKeyType;


### PR DESCRIPTION
Allows setting the textAlignment property for the QEntryElement, helps with layout on the iPad.
