### PR TITLE
Added MapKit and CoreLocation, adapted the new Podspec

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -3,19 +3,18 @@ Pod::Spec.new do |s|
   s.version  = '0.5'
   s.platform = :ios
   s.license  = 'Apache License, Version 2.0'
-  s.summary  = 'Quick and easy dialog screens for iOS'
+  s.summary  = 'Quick and easy dialog screens for iOS.'
   s.homepage = 'http://escoz.com/quickdialog'
   s.author   = { 'Eduardo Scoz' => 'contact@escoz.com' }
-  s.source   = { :git => 'git://github.com/escoz/QuickDialog.git', :tag => '0.5' }
+  s.source   = { :git => 'https://github.com/escoz/QuickDialog.git', :tag => '0.5' }
 
   s.description  = 'QuickDialog allows you to create HIG-compliant iOS forms for your apps without ' \
                    'having to directly deal with UITableViews, delegates and data sources. Fast ' \
                    'and efficient, you can create forms with multiple text fields, or with ' \
                    'thousands of items with no sweat!'
-
   s.source_files = 'quickdialog'
-  s.clean_paths  = 'sample', '*.xc*', 'libQuickDialog', 'other'
   s.requires_arc = true
+  s.frameworks   = 'MapKit', 'CoreLocation'
 
   def s.post_install(target)
     prefix_header = config.project_pods_root + target.prefix_header_filename


### PR DESCRIPTION
When installing via cocoapods, the build fails because of CoreLocation and MapKit frameworks not being included.

This should fix that one, and `clean_paths` are not supported anymore (everything's cleaned by default).
