### PR TITLE
QuickDialogController sub-classing improvements

### DIFF
--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -12,6 +12,7 @@
 // permissions and limitations under the License.
 //
 
+#import "QuickDialogController.h"
 
 @interface QuickDialogController ()
 
@@ -62,7 +63,13 @@
 - (void)loadView {
     [super loadView];
     self.quickDialogTableView = [[QuickDialogTableView alloc] initWithController:self];
-    self.view = self.quickDialogTableView;
+}
+
+// default impl
+- (void)setQuickDialogTableView:(QuickDialogTableView *)tableView
+{
+    _quickDialogTableView = tableView;
+    self.view = tableView;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation


### PR DESCRIPTION
Improve how self.view is assigned to the quickDialogTableView by moving that default assignment to the setter routine setQuickDialogTableView.

Sub-classes can alter that view assignment behavior by providing their own implementation of the setter routine.
