### PR TITLE
Copy Headers: Public

### DIFF
--- a/QuickDialog.xcodeproj/project.pbxproj
+++ b/QuickDialog.xcodeproj/project.pbxproj
@@ -895,7 +895,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = /include/QuickDialog;
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/QuickDialog;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -913,7 +913,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = /include/QuickDialog;
+				PUBLIC_HEADERS_FOLDER_PATH = ../../Headers/QuickDialog;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
This helped me use QuickDialog as a sub-project.
In the Build Phases for QuickDialog target I moved all headers from "Project" section to "Public".
This way they are available along with headers from other libraries in
    "$(BUILT_PRODUCTS_DIR)/../../Headers"
