### PR TITLE
Prevent elements that are hidden from taking focus

### DIFF
--- a/quickdialog/QEntryElement.m
+++ b/quickdialog/QEntryElement.m
@@ -85,7 +85,12 @@
 }
 
 - (BOOL)canTakeFocus {
-    return YES;
+	if (self.hidden) {
+		return NO;
+	}
+	else {
+		return YES;
+	}
 }
 
 #pragma mark - UITextInputTraits


### PR DESCRIPTION
Trivial bug fix.  Elements that are hidden can still currently be selected by Prev/Next buttons, crashing when we try and switch focus to them.

Use the handy "canTakeFocus" method to prevent this.
