### PR TITLE
Fix for hidden sections crasher bug

### DIFF
--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -26,7 +26,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return [_tableView.root getSectionForIndex:section].visibleNumberOfElements;
+    return [_tableView.root getVisibleSectionForIndex:section].visibleNumberOfElements;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Makes tableView:numberOfRowsInSection: take into account hidden sections. It currently returns the number of rows from an incorrect section if one or more sections are hidden.
