### PR TITLE
Support for labeling policies in QDateTimeInlineElement cells

### DIFF
--- a/quickdialog/QDateTimeInlineElement.m
+++ b/quickdialog/QDateTimeInlineElement.m
@@ -72,6 +72,7 @@
     [cell prepareForElement:self inTableView:tableView];
     cell.imageView.image = self.image;
     cell.selectionStyle = UITableViewCellSelectionStyleBlue ;
+    cell.labelingPolicy = self.labelingPolicy;
     return cell;
 
 }


### PR DESCRIPTION
Because QDateTimeInlineElement has its cells created and managed itself, rather than through the `getCellForTableView:` in `QElement.m`, it doesn't pick up which labeling policy has been set for the element. As a consequence, even if you set the labeling policy for the element, you can still run into this overlapping/clipping issue:

![QDateTimeInlineElement labeling policy issue](http://i.imgur.com/UNRFs.png)

This change sets the cell's labeling policy to whatever has been set on the element.
