### PR TITLE
Improve json login example

### DIFF
--- a/sample/Resources/loginform.json
+++ b/sample/Resources/loginform.json
@@ -4,7 +4,7 @@
     "controllerName": "LoginController",
 	"sections": [
 		{ "title":"Awesome Login Form", "headerImage":"logo", "footer":"Please type your credentials.", "elements": [
-				{ "type":"QEntryElement", "title":"Login","placeholder":"Login or email", "bind":"textValue:login", "key":"login"},
+				{ "type":"QEntryElement", "keyboardType":"EmailAddress", "title":"Login","placeholder":"Login or email", "bind":"textValue:login", "key":"login"},
 				{  "type":"QEntryElement", "title":"Password", "placeholder":"Password",  "secureTextEntry":true, "bind":"textValue:password" }
 			]
 		},


### PR DESCRIPTION
QuickDialog allows email keyboard type so I figure why not use it in the example so other people don't have to go digging for it.
