### PR TITLE
Update quickdialog/QSegmentedElement.m

### DIFF
--- a/quickdialog/QSegmentedElement.m
+++ b/quickdialog/QSegmentedElement.m
@@ -95,7 +95,7 @@
     control.frame = frame;
     control.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     control.segmentedControlStyle = 6;
-    control.selectedSegmentIndex = _selected + 1;
+    control.selectedSegmentIndex = _selected;
     control.tag = 4321;
     [control setEnabled:NO forSegmentAtIndex:0];
     [control setEnabled:NO forSegmentAtIndex:item.count-1];


### PR DESCRIPTION
Removed `+1` that caused a change in selection after reshowing up a cell.
Why you wanned this `+1` in the first place?
