### PR TITLE
Do not resize QMultilineTextView for iPad keyboard

### DIFF
--- a/quickdialog/QMultilineTextViewController.m
+++ b/quickdialog/QMultilineTextViewController.m
@@ -72,6 +72,9 @@
 
 
 - (void) resizeForKeyboard:(NSNotification*)aNotification {
+    if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
+        return;
+
     if (!_viewOnScreen)
         return;
 


### PR DESCRIPTION
On the iPad the QMultilineTextView is shown inside a UIPopover so there is no need to resize the view because the popover will be resized on it's own.

If you resize the view under this circumstances then you end up resizing the view twice, once because the popover gets resized to not overlap the keyboard, and another one from the resizeForKeyboard: call.

To see this (wrong) behavior you just need to have a QMultilineElement that is low enough in the screen to overlap with the keyboard and you will see your text fly up as soon as they keyboard overlaps the popover and it gets resized.

kr,
Juan
