### PR TITLE
Fix for case sensitive filesystems

### DIFF
--- a/quickdialog/QRootBuilder.h
+++ b/quickdialog/QRootBuilder.h
@@ -13,7 +13,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "quickdialog.h"
+#import "QuickDialog.h"
 
 @interface QRootBuilder : NSObject {
 


### PR DESCRIPTION
This is a very simple, but to me significant fix.

My iMac has its hard drive configured like most people's macs - its filesystem is set to case insensitive.

However, I decided to be a right weirdo with the Macbook & set its filesystem to be case sensitive.  To be honest, I prefer it not to be, but I don't want to go into the effort of reformatting.

Anyway, QuickDialog builds fine on my iMac, but fails on the Macbook due to this one line not having the correct filename case.  I've corrected it in this pull request & it now builds fine there as well.
