### PR TITLE
Allow QuickDialogTableView to be instantiated from storyboard

### DIFF
--- a/quickdialog/QuickDialogController.h
+++ b/quickdialog/QuickDialogController.h
@@ -31,8 +31,9 @@
 
 @property(nonatomic, retain) QRootElement * root;
 @property(nonatomic, copy) void (^willDisappearCallback)();
-@property(nonatomic, strong) QuickDialogTableView *quickDialogTableView;
+@property(nonatomic, strong) IBOutlet QuickDialogTableView *quickDialogTableView;
 @property(nonatomic) BOOL resizeWhenKeyboardPresented;
+@property(nonatomic) BOOL useStoryboard;
 
 
 @property(nonatomic, strong) UIPopoverController *popoverBeingPresented;

--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -32,6 +32,7 @@
 @synthesize willDisappearCallback = _willDisappearCallback;
 @synthesize quickDialogTableView = _quickDialogTableView;
 @synthesize resizeWhenKeyboardPresented = _resizeWhenKeyboardPresented;
+@synthesize useStoryboard = _useStoryboard;
 @synthesize popoverBeingPresented = _popoverBeingPresented;
 @synthesize popoverForChildRoot = _popoverForChildRoot;
 
@@ -65,13 +66,17 @@
 
 - (void)loadView {
     [super loadView];
-    self.quickDialogTableView = [[QuickDialogTableView alloc] initWithController:self];
+    if (!self.useStoryboard) {
+        self.quickDialogTableView = [[QuickDialogTableView alloc] initWithController:self];
+    }
 }
 
 - (void)setQuickDialogTableView:(QuickDialogTableView *)tableView
 {
     _quickDialogTableView = tableView;
-    self.view = tableView;
+    if (!self.useStoryboard) {
+        self.view = tableView;
+    }
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
@@ -98,6 +103,15 @@
     self.quickDialogTableView.root = root;
     self.title = _root.title;
     self.navigationItem.title = _root.title;
+}
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    if (self.useStoryboard) {
+        [self.quickDialogTableView initController:self];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/quickdialog/QuickDialogTableView.h
+++ b/quickdialog/QuickDialogTableView.h
@@ -42,6 +42,8 @@
 
 - (QuickDialogTableView *)initWithController:(QuickDialogController *)controller;
 
+- (void)initController:(QuickDialogController *)controller;
+
 - (NSIndexPath *)indexForElement:(QElement *)element;
 
 - (UITableViewCell *)cellForElement:(QElement *)element;

--- a/quickdialog/QuickDialogTableView.m
+++ b/quickdialog/QuickDialogTableView.m
@@ -30,19 +30,32 @@
 - (QuickDialogTableView *)initWithController:(QuickDialogController *)controller {
     self = [super initWithFrame:CGRectMake(0, 0, 0, 0) style:controller.root.grouped ? UITableViewStyleGrouped : UITableViewStylePlain];
     if (self!=nil){
-        _controller = controller;
-        self.root = _controller.root;
-        self.deselectRowWhenViewAppears = YES;
-
-        quickformDataSource = [[QuickDialogDataSource alloc] initForTableView:self];
-        self.dataSource = quickformDataSource;
-
-        quickformDelegate = [[QuickDialogTableDelegate alloc] initForTableView:self];
-        self.delegate = quickformDelegate;
-
-        self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        [self initController:controller];
     }
     return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+
+    }
+    return self;
+}
+
+- (void)initController:(QuickDialogController *)controller {
+    _controller = controller;
+    self.root = _controller.root;
+    self.deselectRowWhenViewAppears = YES;
+
+    quickformDataSource = [[QuickDialogDataSource alloc] initForTableView:self];
+    self.dataSource = quickformDataSource;
+
+    quickformDelegate = [[QuickDialogTableDelegate alloc] initForTableView:self];
+    self.delegate = quickformDelegate;
+
+    self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
 }
 
 -(void)setRoot:(QRootElement *)root{


### PR DESCRIPTION
This changeset allows you to use QuickDailogTableView inside complex view layout.

1) Drag UITableView into UIViewController using storyboard
2) Set size and position
3) Assign class name to QuickDailogTableView
4) Add the following to your custom QuickDialogController

``` objc
- (id)initWithCoder:(NSCoder *)aDecoder
{
    self = [super initWithCoder:aDecoder];
    if (self) {
        self.useStoryboard = YES;
    }
    return self;
}
```

It may be useful if you want QuickDialogTableView to take only part of the screen and control size and position via UI. 
