### PR TITLE
Added a way to change placeholder's color of QEntryElement.

### DIFF
--- a/quickdialog/QTextField.h
+++ b/quickdialog/QTextField.h
@@ -17,6 +17,7 @@
 
 @interface QTextField : UITextField
 
+@property (nonatomic, strong) UIColor *placeholderColor;
 @property (nonatomic, copy) NSString *prefix;
 @property (nonatomic, copy) NSString *suffix;
 

--- a/quickdialog/QTextField.m
+++ b/quickdialog/QTextField.m
@@ -16,6 +16,7 @@
 
 @implementation QTextField
 
+@synthesize placeholderColor = _placeholderColor;
 @synthesize prefix = _prefix;
 @synthesize suffix = _suffix;
 
@@ -27,6 +28,15 @@
         [textWithSuffix drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
     } else {
         [super drawTextInRect:rect];
+    }
+}
+
+- (void)drawPlaceholderInRect:(CGRect)rect {
+    if (!_placeholderColor) {
+        [super drawPlaceholderInRect:rect];
+    } else {
+        CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _placeholderColor.CGColor);
+        [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
     }
 }
 


### PR DESCRIPTION
Many designers don't like the default color :)

Now, you can change it just like text color.

```
-(void)cell:(UITableViewCell *)cell willAppearForElement:(QElement *)element atIndexPath:(NSIndexPath *)indexPath {
    QEntryTableViewCell *entryCell = (QEntryTableViewCell*)cell;
    [entryCell.textField setTextColor:[UIColor blackColor]];
    [entryCell.textField setPlaceholderColor:[UIColor blueColor]];
}
```
