### PR TITLE
QPickerTableView : crash when existing value isn't in the picker's list of items

### DIFF
--- a/quickdialog/QPickerTableViewCell.m
+++ b/quickdialog/QPickerTableViewCell.m
@@ -145,7 +145,9 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
     {
         id componentValue = [componentsValues objectAtIndex:(NSUInteger) componentIndex];
         NSInteger rowIndex = [[self.pickerElement.items objectAtIndex:componentIndex] indexOfObject:componentValue];
-        [_pickerView selectRow:rowIndex inComponent:componentIndex animated:YES];
+        if (rowIndex != NSNotFound) {
+            [_pickerView selectRow:rowIndex inComponent:componentIndex animated:YES];
+        }
     }
 }
 


### PR DESCRIPTION
This commit fixes a crash I'm seeing when the existing bound value is not in the list of known values for the picker.

Adds a check for NSNotFound for a call to indexOfObject.
