### PR TITLE
Updated podspec for cocoapods index

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'QuickDialog'
   s.version  = '0.7'
-  s.platform = :ios
+  s.platform = :ios, '5.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Quick and easy dialog screens for iOS.'
   s.homepage = 'http://escoz.com/quickdialog'
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
                    'having to directly deal with UITableViews, delegates and data sources. Fast ' \
                    'and efficient, you can create forms with multiple text fields, or with ' \
                    'thousands of items with no sweat!'
-  s.source_files = 'quickdialog'
+  s.source_files = 'quickdialog', '*.{h,m}' 
   s.requires_arc = true
   s.frameworks   = 'MapKit', 'CoreLocation'
 


### PR DESCRIPTION
We noticed that because there isn't a minimum sdk version set, the project is now breaking in iOS 4.3.

`QRadioItemElement.h:23:5: The current deployment target does not support automated __weak references`

Therefore I am updating the podspec in the index to have a minimum SDK target of 5.0.  Let me know if this is alright with you and I will pull request the change into cocoapods.
