### PR TITLE
QPickerElement now reloads its UI on datasource modification

### DIFF
--- a/quickdialog/QPickerElement.m
+++ b/quickdialog/QPickerElement.m
@@ -31,6 +31,12 @@
     return self;
 }
 
+- (void)setItems:(NSArray *)items
+{
+    _items = items;
+    [_pickerView reloadAllComponents];
+}
+
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller
 {
     QPickerTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:QPickerTableViewCellIdentifier];


### PR DESCRIPTION
By default QPickerElement does not update its UI on item modification leading to a strange behaviour and inconsistencies when modifying its backing data source.

This pull request fixes that by telling the picker to reload its UI when the datasource is modified by the user by setting the items property on QPickerElement class.
