### PR TITLE
QFloatElement: minimum / maximum should default to 0 / 1

### DIFF
--- a/quickdialog/QFloatElement.m
+++ b/quickdialog/QFloatElement.m
@@ -24,6 +24,8 @@
     self = [super initWithTitle:title Value:nil] ;
     if (self) {
         _floatValue = value;
+        _minimumValue = 0.0;
+        _maximumValue = 1.0;
         self.enabled = YES;
     }
     return self;
@@ -34,6 +36,8 @@
     self = [super init];
     if (self) {
         _floatValue = value;
+        _minimumValue = 0.0;
+        _maximumValue = 1.0;
         self.enabled = YES;
     }
     return self;


### PR DESCRIPTION
This commit fixes an issue I'm seeing where the minimum and maximum values for a QElement's slider are both set to 0. This is problematic both for backwards compatibility (older JSON didn't require those values) and also for simplicity.
