### PR TITLE
Adds protection for setting nil values in bindings for float & bool elements

### DIFF
--- a/quickdialog/QBooleanElement.m
+++ b/quickdialog/QBooleanElement.m
@@ -128,4 +128,16 @@
 }
 
 
+- (void)setNilValueForKey:(NSString *)key;
+{
+    if ([key isEqualToString:@"boolValue"]){
+        self.boolValue = NO;
+    }
+    else {
+        [super setNilValueForKey:key];
+    }
+}
+
+
+
 @end

--- a/quickdialog/QFloatElement.m
+++ b/quickdialog/QFloatElement.m
@@ -78,6 +78,16 @@
     return cell;
 }
 
+- (void)setNilValueForKey:(NSString *)key;
+{
+    if ([key isEqualToString:@"floatValue"]){
+        self.floatValue = 0;
+    }
+    else {
+        [super setNilValueForKey:key];
+    }
+}
+
 
 
 


### PR DESCRIPTION
I'm seeing an issue with bindings where a property that is an NSNumber is set to nil:

```
@interface Foo : NSObject
@property (nonatomic, strong) NSNumber *boolNumber;
@end
...
Foo *foo = [[myFoo alloc] init];
foo.boolNumber = nil;
```

Then the property is used as a binding to a QBoolElement. This causes an exception to be thrown, as setting the bool value in QBoolElement to nil is not allowed.

I've added a check for this where it will be set to NO in the case where it's nil.
