### PR TITLE
Fix for issue building QuickDialog with CocoaPods

### DIFF
--- a/quickdialog/QImageElement.h
+++ b/quickdialog/QImageElement.h
@@ -22,7 +22,7 @@
 @property (nonatomic, strong) UIImage *imageValue;
 @property (nonatomic, strong) NSString *imageValueNamed;
 @property (nonatomic, assign) float imageMaxLength;
-@property(nonatomic) enum UIImagePickerControllerSourceType source;
+@property(nonatomic) UIImagePickerControllerSourceType source;
 
 
 - (QImageElement *)initWithTitle:(NSString *)title detailImage:(UIImage *)image;


### PR DESCRIPTION
I was trying to use QuickDialog with CocoaPods and RubyMotion, but I'd get an error at the end of compilation:

Stack dump:
0.      :4:1: current parser token 'void'
/System/Library/BridgeSupport/ruby-1.8/bridgesupportparser.rb:960: [BUG] Segmentation fault

Apparently the gen_bridge_metadata command was running into an error parsing QuickDialog's header files. I did some debugging and was able to narrow down the problem to QImageElement.h. I'm new to Objective-C, but it appears that the type was listed twice, both as enum and UIImagePickerControllerSourceType. The attached change fixes the problem and allows the QuickDialog pod to build successfully.
