### PR TITLE
Replaced deprecated symbols in iOS 6.x

### DIFF
--- a/quickdialog/DOAutocompleteTextField.m
+++ b/quickdialog/DOAutocompleteTextField.m
@@ -64,7 +64,7 @@
     _autocompleteLabel.font = self.font;
     _autocompleteLabel.backgroundColor = [UIColor clearColor];
     _autocompleteLabel.textColor = [UIColor lightGrayColor];
-    _autocompleteLabel.lineBreakMode = UILineBreakModeClip;
+    _autocompleteLabel.lineBreakMode = NSLineBreakByClipping;
     [self addSubview:_autocompleteLabel];
     [self bringSubviewToFront:_autocompleteLabel];
     
@@ -108,12 +108,12 @@
     
     CGSize prefixTextSize = [self.text sizeWithFont:self.font
                                   constrainedToSize:textRect.size
-                                      lineBreakMode:UILineBreakModeCharacterWrap];
+                                      lineBreakMode:NSLineBreakByCharWrapping];
     //    NSLog(@"prefixTextSize: %@",  NSStringFromCGSize(prefixTextSize));
     
     CGSize autocompleteTextSize = [_autoCompleteString sizeWithFont:self.font 
                                                   constrainedToSize:CGSizeMake(textRect.size.width-prefixTextSize.width, textRect.size.height)
-                                                      lineBreakMode:UILineBreakModeCharacterWrap];
+                                                      lineBreakMode:NSLineBreakByCharWrapping];
     
     //    NSLog(@"autocompleteTextSize: %@",  NSStringFromCGSize(autocompleteTextSize)); 
     

--- a/quickdialog/QBadgeLabel.m
+++ b/quickdialog/QBadgeLabel.m
@@ -26,7 +26,7 @@
     self.backgroundColor = [UIColor clearColor];
     self.badgeColor = [UIColor colorWithRed:0.530f green:0.600f blue:0.738f alpha:1.000f];
     self.font = [UIFont boldSystemFontOfSize:14];
-    self.textAlignment = UITextAlignmentCenter;
+    self.textAlignment = NSTextAlignmentCenter;
     self.clipsToBounds = NO;
     return self;
 }

--- a/quickdialog/QEmptyListElement.m
+++ b/quickdialog/QEmptyListElement.m
@@ -28,7 +28,7 @@
     }
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.textLabel.text = _title;
-    cell.textLabel.textAlignment = UITextAlignmentCenter;
+    cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.textColor = [UIColor colorWithWhite:0.7f alpha:1.0f];
     cell.textLabel.font = [UIFont boldSystemFontOfSize:15];
     return cell;

--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -88,7 +88,7 @@
                 QEntryElement *q = (QEntryElement*)el; 
                 CGFloat imageWidth = q.image == NULL ? 0 : self.imageView.frame.size.width;
                 CGFloat fontSize = self.textLabel.font.pointSize == 0? 17 : self.textLabel.font.pointSize;
-                CGSize size = [((QEntryElement *)el).title sizeWithFont:[self.textLabel.font fontWithSize:fontSize] forWidth:CGFLOAT_MAX lineBreakMode:UILineBreakModeWordWrap] ;
+                CGSize size = [((QEntryElement *)el).title sizeWithFont:[self.textLabel.font fontWithSize:fontSize] forWidth:CGFLOAT_MAX lineBreakMode:NSLineBreakByWordWrapping] ;
                 CGFloat width = size.width + imageWidth;
                 if (width>titleWidth)
                     titleWidth = width;

--- a/quickdialog/QTextElement.m
+++ b/quickdialog/QTextElement.m
@@ -41,7 +41,7 @@
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"QuickformText"];
     }
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    cell.detailTextLabel.lineBreakMode = UILineBreakModeWordWrap;
+    cell.detailTextLabel.lineBreakMode = NSLineBreakByWordWrapping;
     cell.detailTextLabel.numberOfLines = 0;
 
     cell.textLabel.adjustsFontSizeToFitWidth = YES;
@@ -60,7 +60,7 @@
         return [super getRowHeightForTableView:tableView];
     }
     CGSize constraint = CGSizeMake(tableView.frame.size.width-(tableView.root.grouped ? 40.f : 20.f), 20000);
-    CGSize  size= [_text sizeWithFont:_font constrainedToSize:constraint lineBreakMode:UILineBreakModeWordWrap];
+    CGSize  size= [_text sizeWithFont:_font constrainedToSize:constraint lineBreakMode:NSLineBreakByWordWrapping];
 	CGFloat predictedHeight = size.height + 20.0f;
     if (self.title!=nil)
         predictedHeight+=30;

--- a/quickdialog/QTextField.m
+++ b/quickdialog/QTextField.m
@@ -24,7 +24,7 @@
     if (_prefix || _suffix) {
         NSString *textWithSuffix = [NSString stringWithFormat:@"%@%@%@", _prefix ? _prefix : @"", self.text, _suffix ? _suffix : @""];
         CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), self.textColor.CGColor);
-        [textWithSuffix drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
+        [textWithSuffix drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
     } else {
         [super drawTextInRect:rect];
     }

--- a/quickdialog/QuickDialogController+Navigation.m
+++ b/quickdialog/QuickDialogController+Navigation.m
@@ -8,12 +8,12 @@
 
 - (void)displayViewController:(UIViewController *)newController {
     if ([newController isKindOfClass:[UINavigationController class]]) {
-        [self presentModalViewController:newController animated:YES];
+        [self presentViewController:newController animated:YES completion:nil];
     }
     else if (self.navigationController != nil){
         [self.navigationController pushViewController:newController animated:YES];
     } else {
-        [self presentModalViewController:[[UINavigationController alloc] initWithRootViewController:newController] animated:YES];
+        [self presentViewController:[[UINavigationController alloc] initWithRootViewController:newController] animated:YES completion:nil];
     }
 }
 
@@ -28,23 +28,22 @@
         UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController :newController];
         newController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Close" style:UIBarButtonItemStyleDone target:self action:@selector(dismissModalViewController)];
         navigation.modalPresentationStyle = UIModalPresentationFormSheet;
-        [self presentModalViewController:navigation animated:YES];
+        [self presentViewController:navigation animated:YES completion:nil];
     }  else if (root.presentationMode == QPresentationModeModalFullScreen) {
         UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController :newController];
         newController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Close" style:UIBarButtonItemStyleDone target:self action:@selector(dismissModalViewController)];
         navigation.modalPresentationStyle = UIModalPresentationFullScreen;
-        [self presentModalViewController:navigation animated:YES];
+        [self presentViewController:navigation animated:YES completion:nil];
     }  else if (root.presentationMode == QPresentationModeModalPage) {
         UINavigationController *navigation = [[UINavigationController alloc] initWithRootViewController :newController];
         newController.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Close" style:UIBarButtonItemStyleDone target:self action:@selector(dismissModalViewController)];
         navigation.modalPresentationStyle = UIModalPresentationPageSheet;
-        [self presentModalViewController:navigation animated:YES];
+        [self presentViewController:navigation animated:YES completion:nil];
     }
 }
 
 - (void)dismissModalViewController {
-    [self dismissModalViewControllerAnimated:YES];
-
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)displayViewControllerInPopover:(UIViewController *)newController withNavigation:(BOOL)navigation fromRect:(CGRect)position {
@@ -91,7 +90,7 @@
     } else if (self.presentingViewController!=nil)
         [self dismissViewControllerAnimated:YES completion:nil];
     else {
-        [self dismissModalViewControllerAnimated:YES];
+        [self dismissViewControllerAnimated:YES completion:nil];
     }
 }
 

--- a/quickdialog/QuickDialogStyleProvider.h
+++ b/quickdialog/QuickDialogStyleProvider.h
@@ -12,6 +12,7 @@
 // permissions and limitations under the License.
 //
 
+#import <UIKit/UIKit.h>
 
 @class QElement;
 @class QSection;

--- a/quickdialog/QuickDialogTableDelegate.m
+++ b/quickdialog/QuickDialogTableDelegate.m
@@ -91,7 +91,7 @@
         QAppearance *appearance = ((QuickDialogTableView *)tableView).root.appearance;
         CGSize expectedLabelSize = [section.title sizeWithFont:appearance==nil? [UIFont systemFontOfSize:[UIFont labelFontSize]] : appearance.sectionTitleFont
                                               constrainedToSize:maximumLabelSize
-                                                  lineBreakMode:UILineBreakModeWordWrap];
+                                                  lineBreakMode:NSLineBreakByWordWrapping];
 
         stringTitleHeight = expectedLabelSize.height+23.f;
     }


### PR DESCRIPTION
Since at least 83% of the iOS user base is now using iOS 6.x, I would think it's pretty safe to clean up the code by removing the symbols that no longer should be used. Here are the changes I made.

One warning I didn't take care of is the following:

/Users/tciuro/Desktop/Momo/QuickDialog/quickdialog/QBadgeTableCell.m:32:21: 'contentStretch' is deprecated: first deprecated in iOS 6.0

This may need a more complex fix, so I'll leave it up to you ;-)

Regards,

-- Tito
