### PR TITLE
Deselect previous / next buttons after pressing them.

### DIFF
--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -267,6 +267,8 @@
             });
         }
 	}
+
+    [control setSelectedSegmentIndex:UISegmentedControlNoSegment];
 }
 
 - (BOOL)handleActionBarDone:(UIBarButtonItem *)doneButton {


### PR DESCRIPTION
This fixes a lot of weird issues related to the prev / next buttons
state that would cause one or both buttons to not be active. Instead,
they'd be in a defunct selected state.
