### PR TITLE
canTakeFocus now returns NO if element is not enabled.

### DIFF
--- a/quickdialog/QEntryElement.m
+++ b/quickdialog/QEntryElement.m
@@ -88,12 +88,7 @@
 }
 
 - (BOOL)canTakeFocus {
-	if (self.hidden) {
-		return NO;
-	}
-	else {
-		return YES;
-	}
+    return self.enabled && !self.hidden;
 }
 
 #pragma mark - UITextInputTraits


### PR DESCRIPTION
This fixes an issue where the previous / next buttons would still
select disabled elements.
