### PR TITLE
Use QElement::getIndexPath instead of QuickDialogTableView::visibleIndexForElement:

### DIFF
--- a/quickdialog/QuickDialogTableView.m
+++ b/quickdialog/QuickDialogTableView.m
@@ -86,32 +86,10 @@
     return NULL;
 }
 
-- (NSIndexPath *)visibleIndexForElement:(QElement *)element {
-    if (element.hidden)
-        return NULL;
-    
-    NSUInteger s = 0;
-    for (QSection * q in _root.sections)
-    {
-        if (!q.hidden)
-        {
-            NSUInteger e = 0;
-            for (QElement * r in q.elements)
-            {
-                if (r == element)
-                    return [NSIndexPath indexPathForRow:e inSection:s];
-                ++e;
-            }
-        }
-        ++s;
-    }
-    return NULL;
-}
-
 - (UITableViewCell *)cellForElement:(QElement *)element {
     if (element.hidden)
         return nil;
-    return [self cellForRowAtIndexPath:[self visibleIndexForElement:element]];
+    return [self cellForRowAtIndexPath:[element getIndexPath]];
 }
 
 - (void)viewWillAppear {


### PR DESCRIPTION
QuickDialogTableView::visibleIndexForElement: returns an incorrect
result after rows have been deleted dynamically from the tableview.

Since this method gives incorrect results and is only used in 1 place,
I deleted it and replaced it with QElement::getIndexPath which returns
the correct result.
