### PR TITLE
QDecimalTableViewCell should respect shouldChange result from its delegate

### DIFF
--- a/quickdialog/QDecimalTableViewCell.m
+++ b/quickdialog/QDecimalTableViewCell.m
@@ -76,14 +76,17 @@
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)replacement {
-    NSString *newValue = [_textField.text stringByReplacingCharactersInRange:range withString:replacement];
-    [self updateElementFromTextField:newValue];
-    [self updateTextFieldFromElement];
+    BOOL shouldChange = YES;
     
-    if(_entryElement && _entryElement.delegate && [_entryElement.delegate respondsToSelector:@selector(QEntryShouldChangeCharactersInRangeForElement:andCell:)]){
-        [_entryElement.delegate QEntryShouldChangeCharactersInRange:range withString:replacement forElement:_entryElement andCell:self];
+    if(_entryElement && _entryElement.delegate && [_entryElement.delegate respondsToSelector:@selector(QEntryShouldChangeCharactersInRangeForElement:andCell:)])
+        shouldChange = [_entryElement.delegate QEntryShouldChangeCharactersInRange:range withString:replacement forElement:_entryElement andCell:self];
+    
+    if( shouldChange ) {
+        NSString *newValue = [_textField.text stringByReplacingCharactersInRange:range withString:replacement];
+        [self updateElementFromTextField:newValue];
+        [self updateTextFieldFromElement];
     }
-
+    
     return NO;
 }
 


### PR DESCRIPTION
I wasn't able to enforce a maximum length on a `QDecimalElement` because `QDecimalTableViewCell` doesn't do anything with the result of `-(BOOL)QEntryShouldChangeCharactersInRange:withString:forElement:andCell:`. 

It does now!
