### PR TITLE
Fixed issue with UIDatePicker of QCountDownElement not showing proper value.

### DIFF
--- a/quickdialog/QDateEntryTableViewCell.m
+++ b/quickdialog/QDateEntryTableViewCell.m
@@ -59,8 +59,10 @@ UIDatePicker *QDATEENTRY_GLOBAL_PICKER;
     _pickerView.minimumDate = element.minimumDate;
     _pickerView.minuteInterval = element.minuteInterval;
     
-    if (element.dateValue!=nil)
+    if (element.mode != UIDatePickerModeCountDownTimer && element.dateValue != nil)
         _pickerView.date = element.dateValue;
+    else if (element.mode == UIDatePickerModeCountDownTimer && element.ticksValue != nil)
+        _pickerView.countDownDuration = [element.ticksValue doubleValue];
 
     [super textFieldDidBeginEditing:textField];
     self.selected = YES;

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -588,6 +588,11 @@
     QDateTimeInlineElement *elDiffTime = [[QDateTimeInlineElement alloc] initWithTitle:@"Different date" date:
             [NSDate dateWithTimeIntervalSinceNow:-36000]];
     [section addElement:elDiffTime];
+    
+    QCountdownElement *countDown = [[QCountdownElement alloc] init];
+    countDown.title = @"Countdown";
+    countDown.ticksValue = [NSNumber numberWithDouble: 9780.0]; // 2Hr 43Min
+    [section addElement:countDown];    
 
     QSection *section2 = [[QSection alloc] init];
     section2.title = @"Push editing";


### PR DESCRIPTION
When used as a countdown timer, a UIDatePicker needs the countDownDuration property to be set.  

This patch fixes this issue and also adds an example to to the "Date Time" section of the Usage Examples.
