### PR TITLE
Fix for split keyboard on iPad

### DIFF
--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -127,7 +127,7 @@
     return [QuickDialogController buildControllerWithClass:controllerClass root:root];
 }
 
-- (void)keyboardDidChangeFrame:(NSNotification *)notification
+- (void)keyboardWillChangeFrame:(NSNotification *)notification
 {
     NSDictionary* userInfo = [notification userInfo];
     CGRect keyboardEndFrame;
@@ -165,7 +165,7 @@
         
         if (_resizeWhenKeyboardPresented) {
             
-            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidChangeFrame:) name:UIKeyboardWillChangeFrameNotification              object:nil];
+            [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification              object:nil];
         } else {
             
             [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];


### PR DESCRIPTION
When the keyboard is split on an iPad it doesn't use the same notifications, instead it uses the keyboardWillChangeFrame notification.  I've updated the logic around the keyboard to now use this notification instead.  This keeps the keyboard from hiding content when it's split.
