### PR TITLE
Fixes an issue with undefined QElement types crashing app

### DIFF
--- a/quickdialog/QRootBuilder.m
+++ b/quickdialog/QRootBuilder.m
@@ -112,7 +112,10 @@ NSDictionary *QRootBuilderStringToTypeConversionDict;
     [self updateObject:sect withPropertiesFrom:obj];
     [root addSection:sect];
     for (id element in (NSArray *)[obj valueForKey:[NSString stringWithFormat:@"elements"]]){
-       [sect addElement:[self buildElementWithObject:element] ];
+        QElement *elementNode = [self buildElementWithObject:element];
+        if (elementNode) {
+            [sect addElement:elementNode];
+        }
     }
 }
 


### PR DESCRIPTION
Consider the case of JSON for the QuickDialog views downloaded via the network. Custom types can be defined, which need to map to QElement subclasses. The types defined in the JSON may or may not be supported by the current version of the app.

For example, add this line to the loginform.json, in the last section:
        { "type":"MyNewQElementSubclass"}

Currently this crashes when the nil QElement is added to the section. 

This fixes that issue by skipping such an element.
