### PR TITLE
Removed automatic require from podspec

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -15,12 +15,5 @@ Pod::Spec.new do |s|
   s.source_files = 'quickdialog', '*.{h,m}' 
   s.requires_arc = true
   s.frameworks   = 'MapKit', 'CoreLocation'
-
-  def s.post_install(target)
-    prefix_header = config.project_pods_root + target.prefix_header_filename
-    prefix_header.open('a') do |file|
-      file.puts(%{#ifdef __OBJC__\n#import "QuickDialog.h"\n#endif})
-    end
-  end
 end
 


### PR DESCRIPTION
There are 2 reasons for this:
- `config` is deprecated in newer versions of CocoaPods, and it randomly crashes compiler on a bigger project
- usually there's just a couple of controllers in the app that need to require QuickDialog. It's not needed to be required in the .pch
