### PR TITLE
Make cells user interaction respect their element's enabled property

### DIFF
--- a/quickdialog/QButtonElement.m
+++ b/quickdialog/QButtonElement.m
@@ -42,7 +42,6 @@
     cell.textLabel.textAlignment = self.appearance.buttonAlignment;
     cell.textLabel.font = self.appearance.labelFont;
     cell.textLabel.textColor = self.enabled ? self.appearance.actionColorEnabled : self.appearance.actionColorDisabled;
-    cell.userInteractionEnabled = self.enabled;
     return cell;
 }
 

--- a/quickdialog/QElement.m
+++ b/quickdialog/QElement.m
@@ -63,7 +63,6 @@
     cell.textLabel.text = nil; 
     cell.detailTextLabel.text = nil; 
     cell.imageView.image = nil; 
-    cell.userInteractionEnabled = self.enabled;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.showsReorderControl = YES;
     cell.accessoryView = nil;

--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -34,6 +34,7 @@
     QSection *section = [_tableView.root getVisibleSectionForIndex:indexPath.section];
     QElement *element = [section getVisibleElementForIndex:indexPath.row];
     UITableViewCell *cell = [element getCellForTableView:(QuickDialogTableView *) tableView controller:_tableView.controller];
+    cell.userInteractionEnabled = element.enabled;
     return cell;
 }
 


### PR DESCRIPTION
cell.userInteractionEnabled is now equal to the enabled property of the Element it belongs to.

This fixes a bug that still allowed you to select cells whose Elements had been disabled dynamically.

e.g.:  Let's say we have 2 QPickerElements. The second QPickerElement changes it's options based on the value of the first. If the first QPickerElement value is empty, then the second QPickerElement should have no values, and should be disabled.

With this fix, you can set secondQPickerElement.enabled = NO and then use UITableView's reloadRowsAtIndexPaths:withRowAnimation to properly disable it in the UITableView.

This was not possible before, because the userInteractionEnabled property was only set correctly in the implementation of QButtonElement and QElement, which wasn't always reached because not all QElement subclasses call super (e.g. QPickerElement)
