### PR TITLE
Deselect QMultiLineElement when back

### DIFF
--- a/quickdialog/QMultilineElement.m
+++ b/quickdialog/QMultilineElement.m
@@ -69,6 +69,7 @@
     textController.willDisappearCallback = ^ {
         weakSelf.textValue = weakTextController.textView.text;
         [[tableView cellForElement:weakSelf] setNeedsDisplay];
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
     };
     [controller displayViewControllerInPopover:textController withNavigation:NO];
 }


### PR DESCRIPTION
Before this change when the view pop back the cell didn't deselect
automatically
