### PR TITLE
HighlightedImage support for QLabelElement and subclasses

### DIFF
--- a/quickdialog/QAutoEntryElement.m
+++ b/quickdialog/QAutoEntryElement.m
@@ -65,6 +65,7 @@
     cell.textField.userInteractionEnabled = self.enabled;
     cell.textField.textAlignment = self.appearance.entryAlignment;
     cell.imageView.image = self.image;
+    cell.imageView.highlightedImage = self.highlightedImage;
     [cell prepareForElement:self inTableView:tableView];
     return cell;
 }

--- a/quickdialog/QBadgeElement.m
+++ b/quickdialog/QBadgeElement.m
@@ -49,6 +49,7 @@
     cell.accessoryType = UITableViewCellAccessoryNone;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.imageView.image = _image;
+    cell.imageView.highlightedImage = _highlightedImage;
     cell.accessoryType = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone;
     cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
     return cell;

--- a/quickdialog/QDateTimeInlineElement.m
+++ b/quickdialog/QDateTimeInlineElement.m
@@ -83,6 +83,7 @@
     cell.textField.enabled = self.enabled;
     cell.textField.userInteractionEnabled = self.enabled;
     cell.imageView.image = self.image;
+    cell.imageView.highlightedImage = self.highlightedImage;
     cell.labelingPolicy = self.labelingPolicy;
     return cell;
 }

--- a/quickdialog/QElement.m
+++ b/quickdialog/QElement.m
@@ -62,7 +62,8 @@
 
     cell.textLabel.text = nil; 
     cell.detailTextLabel.text = nil; 
-    cell.imageView.image = nil; 
+    cell.imageView.image = nil;
+    cell.imageView.highlightedImage = nil;
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
     cell.showsReorderControl = YES;
     cell.accessoryView = nil;

--- a/quickdialog/QEntryElement.m
+++ b/quickdialog/QEntryElement.m
@@ -66,6 +66,7 @@
     cell.textField.userInteractionEnabled = self.enabled;
     cell.textField.textAlignment = self.appearance.entryAlignment;
     cell.imageView.image = self.image;
+    cell.imageView.highlightedImage = self.highlightedImage;
     [cell prepareForElement:self inTableView:tableView];
     return cell;
 }

--- a/quickdialog/QLabelElement.h
+++ b/quickdialog/QLabelElement.h
@@ -22,10 +22,13 @@
 @protected
     id _value;
     UIImage *_image;
+    UIImage *_highlightedImage;
 }
 
 @property(nonatomic, strong) UIImage *image;
+@property(nonatomic, strong) UIImage *highlightedImage;
 @property(nonatomic, assign) NSString *imageNamed;
+@property(nonatomic, assign) NSString *highlightedImageNamed;
 @property(nonatomic, assign) UITableViewCellAccessoryType accessoryType;
 @property(nonatomic, strong) id value;
 

--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -22,6 +22,7 @@
 
 
 @synthesize image = _image;
+@synthesize highlightedImage = _highlightedImage;
 @synthesize value = _value;
 @synthesize accessoryType = _accessoryType;
 @synthesize keepSelected = _keepSelected;
@@ -39,6 +40,10 @@
     self.image = [UIImage imageNamed:name];
 }
 
+-(void)setHighlightedImageNamed:(NSString *)highlightedImageName {
+    self.highlightedImage = [UIImage imageNamed:highlightedImageName];
+}
+
 - (NSString *)imageNamed {
     return nil;
 }
@@ -50,6 +55,7 @@
     cell.textLabel.text = _title;
     cell.detailTextLabel.text = [_value description];
     cell.imageView.image = _image;
+    cell.imageView.highlightedImage = _highlightedImage;
     cell.accessoryType = _accessoryType != UITableViewCellAccessoryNone ? _accessoryType : ( self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone);
     cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
 

--- a/quickdialog/QPickerElement.m
+++ b/quickdialog/QPickerElement.m
@@ -44,6 +44,7 @@
     _pickerView = pickerView;
     
     cell.imageView.image = self.image;
+    cell.imageView.highlightedImage = self.highlightedImage;
     
     return cell;
 }


### PR DESCRIPTION
Added a highlightedImage property to QLabelElement and updated subclasses to
properly transfer this property to the Element's
cell.imageView.highlightedImage property.

This allows you to have nice images when a row is selected (e.g. a
picker cell with an image).
