### PR TITLE
Fix QSegmentedElement display problem

### DIFF
--- a/quickdialog/QSegmentedElement.m
+++ b/quickdialog/QSegmentedElement.m
@@ -55,14 +55,13 @@
     cell.backgroundColor = [UIColor clearColor];
     UISegmentedControl *control = [[UISegmentedControl alloc] initWithItems:_items];
     [control addTarget:self action:@selector(handleSegmentedControlValueChanged:) forControlEvents:UIControlEventValueChanged];
-    const BOOL isPhone = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone;
-    control.frame = CGRectMake(isPhone ? 9 : 30, 0, isPhone ? 302 : 260, self.height);
-    control.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    control.frame = cell.contentView.bounds;
+    control.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     control.segmentedControlStyle = UISegmentedControlStyleBar;
     control.selectedSegmentIndex = _selected;
     control.tag = 4321;
     
-    [cell addSubview:control];
+    [cell.contentView addSubview:control];
     return cell;
 }
 


### PR DESCRIPTION
Remove UIUserInterfaceIdiom specific code and instead make the
segmented control resize it's own width and height, with an initial
frame matching the cell.contentView.

Also add the segmentedcontrol to the cell's contentView rather than to
the cell directly.

This fixes the QSegmentedControl rendering issues that are visible in the iPhone and
iPad versions of the QuickDialog example as shown in #480.
