### PR TITLE
Fix QColorPickerElement getImageFromItem: method

### DIFF
--- a/quickdialog/QColorPickerElement.m
+++ b/quickdialog/QColorPickerElement.m
@@ -17,8 +17,9 @@
         self.items = @[
                 @[@"Black", [UIColor blackColor]],
                 @[@"White", [UIColor whiteColor]],
-                @[@"Blue", [UIColor grayColor]],
-                @[@"Red",  [UIColor blueColor]],
+                @[@"Gray", [UIColor grayColor]],
+                @[@"Blue",  [UIColor blueColor]],
+                @[@"Red",  [UIColor redColor]],
                 @[@"Green", [UIColor greenColor]],
                 @[@"Yellow", [UIColor yellowColor]],
                 @[@"Purple", [UIColor purpleColor]],


### PR DESCRIPTION
The `getImageFromItem:` creates an image for the selected item, but it gets the description of the selected item before checking if that item is a UIColor. Because of this, if your item actually is a UIColor, you just end up with a black circle.

Oh, and while I was at it I fixed up the default items for a QColorPickerElement. Some of the names and colors got mismatched.
