### PR TITLE
selectionStyle is wrong for QLabelElement

### DIFF
--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -51,7 +51,7 @@
     cell.detailTextLabel.text = [_value description];
     cell.imageView.image = _image;
     cell.accessoryType = _accessoryType != UITableViewCellAccessoryNone ? _accessoryType : ( self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone);
-    cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
+    cell.selectionStyle = self.sections!= nil || self.controllerAction!=nil || self.onSelected!=nil ? UITableViewCellSelectionStyleBlue: UITableViewCellSelectionStyleNone;
 
     return cell;
 }


### PR DESCRIPTION
The selectionStyle for a QLabelElement is set to blue only if controllerAction is != nil. However it should be also when the onSelected block is != nil.
