### PR TITLE
Check whether value is NSNull.

### DIFF
--- a/quickdialog/QRootBuilder.m
+++ b/quickdialog/QRootBuilder.m
@@ -58,6 +58,8 @@ NSDictionary *QRootBuilderStringToTypeConversionDict;
         [target setValue:itemsTranslated forKeyPath:propertyName];
     } else if ([value isKindOfClass:[NSDictionary class]]){
         [target setValue:value forKeyPath:propertyName];
+    } else if (value == [NSNull null]) {
+        [target setValue:nil forKeyPath:propertyName];
     } else if ([value isKindOfClass:[NSObject class]]){
         [target setValue:value forKeyPath:propertyName];
     } else if (value == nil){


### PR DESCRIPTION
Check whether value is NSNull. When dynamically set property to nil, we must send [NSNull null] instead of nil which can't be set as an NSDictionary value.
