### PR TITLE
changed property name of QDecimalElement from 'floatValue' to 'numberValue'

### DIFF
--- a/quickdialog/QDecimalElement.h
+++ b/quickdialog/QDecimalElement.h
@@ -19,7 +19,7 @@
 
 }
 
-@property(nonatomic, retain) NSNumber * floatValue;
+@property(nonatomic, retain) NSNumber * numberValue;
 @property(nonatomic, assign) NSUInteger fractionDigits;
 
 - (QDecimalElement *)initWithTitle:(NSString *)string value:(NSNumber *)value;

--- a/quickdialog/QDecimalElement.m
+++ b/quickdialog/QDecimalElement.m
@@ -22,32 +22,32 @@
     NSUInteger _fractionDigits;
 }
 
-@synthesize floatValue = _floatValue;
+@synthesize numberValue = _numberValue;
 @synthesize fractionDigits = _fractionDigits;
 
 
 - (QDecimalElement *)initWithTitle:(NSString *)title value:(NSNumber *)value {
     self = [super initWithTitle:title Value:nil] ;
-    _floatValue = value;
+    _numberValue = value;
     return self;
 }
 
 - (void)setFloatValue:(NSNumber *)floatValue {
-    _floatValue = floatValue;
-    if (_floatValue==nil)
-        _floatValue = @0;
+    _numberValue = floatValue;
+    if (_numberValue==nil)
+        _numberValue = @0;
 }
 
 - (QDecimalElement *)initWithValue:(NSNumber *)value {
     self = [super init];
-    _floatValue = value;
+    _numberValue = value;
     return self;
 }
 
 - (QEntryElement *)init {
     self = [super init];
     if (self) {
-        _floatValue = @0;
+        _numberValue = @0;
     }
 
     return self;
@@ -70,7 +70,7 @@
 - (void)fetchValueIntoObject:(id)obj {
 	if (_key==nil)
 		return;
-    [obj setValue:_floatValue forKey:_key];
+    [obj setValue:_numberValue forKey:_key];
 }
 
 @end

--- a/quickdialog/QDecimalTableViewCell.m
+++ b/quickdialog/QDecimalTableViewCell.m
@@ -51,7 +51,7 @@
     [_numberFormatter setMaximumFractionDigits:[self decimalElement].fractionDigits];
     [_numberFormatter setMinimumFractionDigits:[self decimalElement].fractionDigits]; 
     QDecimalElement *el = (QDecimalElement *)_entryElement;
-    _textField.text = [_numberFormatter stringFromNumber:el.floatValue];
+    _textField.text = [_numberFormatter stringFromNumber:el.numberValue];
 }
 
 - (void)prepareForElement:(QEntryElement *)element inTableView:(QuickDialogTableView *)view {
@@ -72,7 +72,7 @@
     [_numberFormatter setMaximumFractionDigits:[self decimalElement].fractionDigits]; 
     [_numberFormatter setMinimumFractionDigits:[self decimalElement].fractionDigits];
     float parsedValue = [_numberFormatter numberFromString:result].floatValue;
-    [self decimalElement].floatValue = [NSNumber numberWithFloat:(float) (parsedValue / pow(10, [self decimalElement].fractionDigits))];
+    [self decimalElement].numberValue = [NSNumber numberWithFloat:(float) (parsedValue / pow(10, [self decimalElement].fractionDigits))];
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)replacement {


### PR DESCRIPTION
The current implementation has a property of type NSNumber name 'floatValue', this breaks convention and makes it difficult to integrate with other projects.  Renamed to 'numberValue', which is more standard.
