### PR TITLE
Allow QSelectSection to work with subclasses of QSelectItemElement.

### DIFF
--- a/quickdialog/QSelectSection.m
+++ b/quickdialog/QSelectSection.m
@@ -102,10 +102,9 @@
 
 - (void)addElement:(QElement *)element {
     [super addElement:element];
-    if ([element isMemberOfClass:[QSelectItemElement class]]){
+    if ([element isKindOfClass:[QSelectItemElement class]]){
         ((QSelectItemElement *)element).selectSection = self;
         ((QSelectItemElement *)element).index = self.elements.count-1;
-
     }
 }
 


### PR DESCRIPTION
Changed the `isMemberOfClass:` call in the `addElement:` method
to `isKindOfClass:` to allow for proper subclassing of
QSelectItemElement.

I ran into this bug wondering why my `AttributedSelectItemElement`
subclass of `QSelectItemElement`
subclass didn't seem to work as expected.
