### PR TITLE
TextLabel takes maximum amount of space if no detailText is set.

### DIFF
--- a/quickdialog/QTableViewCell.m
+++ b/quickdialog/QTableViewCell.m
@@ -66,8 +66,11 @@ static const int kCellMinimumLabelWidth = 40;
         }
 
         CGSize valueSize = CGSizeZero;
-        if (self.textLabel.text!=nil)
+        if (!self.detailTextLabel.text) {
+            valueSize = sizeWithMargin;
+        } else if (self.textLabel.text!=nil) {
             valueSize = [self.textLabel.text sizeWithFont:self.textLabel.font constrainedToSize:sizeWithMargin];
+        }
 
         self.textLabel.frame = CGRectMake(
                 self.textLabel.frame.origin.x,


### PR DESCRIPTION
This fixes the bug mentioned in #545 where button labels text does not get properly centered.

The reason the text does not appear centered is because the textLabel.frame is only wide enough to fit it's content. With this fix, it takes up as much space as possible, as long as detailTextLabel.text is nil (which is the case for QButtonElement).
