### PR TITLE
added extras dir to podspec

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
                    'thousands of items with no sweat!'
 
   s.source_files = 'quickdialog', 'extras', '*.{h,m}'
+  s.frameworks = 'MapKit', 'CoreLocation'
   s.requires_arc = true
 
   s.prefix_header_contents = <<-EOS


### PR DESCRIPTION
Not sure if this was an oversight, or if you had other plans, but I had to add the 'extras' dir and the two required frameworks to the podspec to get my pod-managed copy of QuickDialog to compile.
