### PR TITLE
Fix github commits json example.

### DIFF
--- a/quickdialog/QBindingEvaluator.m
+++ b/quickdialog/QBindingEvaluator.m
@@ -116,6 +116,9 @@
 }
 
 - (void)bindSection:(QSection *)section toProperties:(NSDictionary *)object {
+    if ([object isKindOfClass:[NSNull class]]) {
+        return;
+    }
     [section.elements removeAllObjects];
     for (id item in [object allKeys]){
         QElement *element = [_builder buildElementWithObject:section.elementTemplate];

--- a/sample/Resources/jsonremote.json
+++ b/sample/Resources/jsonremote.json
@@ -2,26 +2,65 @@
 	"grouped": false,
 	"title": "Remote Files",
     "controllerName": "QuickDialogWebController",
-    "object":"https://github.com/api/v2/json/commits/list/escoz/quickdialog/master",
-	"sections": [
+    "object":"https://api.github.com/repos/escoz/quickdialog/commits",
+	"sections":
+    [
         {
-            "elements":[
-                { "type":"QTextElement", "text":"This controller automatically downloads data from the web and binds it to the form. Data is downloaded from GitHub."}
+            "elements":
+            [
+                {
+                    "type":"QTextElement",
+                    "text":"This controller automatically downloads data from the web and binds it to the form. Data is downloaded from GitHub."
+                }
             ]
         },
-        { "title":"Commits for QuickDialog", "bind":"iterate:commits", "elementTemplate":
-				{ "type":"QTextElement", "bind":"text:message, title:committed_date", "controllerName":"QuickDialogController", "grouped":true, "sections":[
-                    {"title":"Dates", "elements":[
-                        { "type":"QLabelElement", "title":"Committed date", "bind":"value:committed_date"},
-                        { "type":"QLabelElement", "title":"Authored date", "bind":"value:authored_date"}
-                    ]},
-                    {"title":"Committer", "bind":"iterateproperties:committer", "elementTemplate":
-                        { "type":"QLabelElement", "bind":"title:key, value:value"}
+        {
+            "title":"Commits for QuickDialog",
+            "bind":"iterate:@allObjects",
+            "elementTemplate":
+            {
+                "type":"QTextElement",
+                "bind":"text:commit.message, title:sha",
+                "controllerName":"QuickDialogController",
+                "grouped":true,
+                "sections":
+                [
+                    {
+                        "title":"Dates",
+                        "elements":
+                        [
+                            {
+                                "type":"QLabelElement",
+                                "title":"Committed date",
+                                "bind":"value:commit.committer.date"
+                            },
+                            {
+                                "type":"QLabelElement",
+                                "title":"Authored date",
+                                "bind":"value:commit.author.date"
+                            }
+                         ]
                     },
-                    {"title":"Author", "bind":"iterateproperties:author", "elementTemplate":
-                        { "type":"QLabelElement", "bind":"title:key, value:value"}
+                    {
+                        "title":"Committer",
+                        "bind":"iterateproperties:committer",
+                        "elementTemplate":
+                        {
+                            "type":"QLabelElement",
+                            "bind":"title:key, value:value"
+                        }
+                    },
+                    {
+                        "title":"Author",
+                        "bind":"iterateproperties:author",
+                        "elementTemplate":
+                        {
+                            "type":"QLabelElement",
+                            "bind":"title:key, value:value"
+                        }
                     }
-                ]}
+                ]
+            }
         }
 	]
 }


### PR DESCRIPTION
The github API used in the `jsonremote.json` example is no longer available: `https://github.com/api/v2/json/commits/list/escoz/quickdialog/master`.

The new `jsonremote.json` now uses `https://github.com/api/v2/json/commits/list/escoz/quickdialog/master` and has the appropriate bindings for the new commits format.

In addition to the json changes, `QBindingEvaluator.m` was updated as well. The problem is that the "authors" element in some of the responses is null/missing, resulting in an exception when trying to call `[object allKeys]` in `-[QBindingEvaluator bindSection:toProperties:]`. 

The quick fix was to check for an `NSNull` value but I suspect a better solution would be to fail more gracefully when binding in general.
