### PR TITLE
Podspec is broken

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
                    'thousands of items with no sweat!'
 
   s.source_files = 'quickdialog', 'extras', '*.{h,m}'
+  s.frameworks = 'MapKit', 'CoreLocation'
   s.requires_arc = true
 
   s.prefix_header_contents = <<-EOS


### PR DESCRIPTION
I posted this on my last pull request that you closed (#550) . I don't think you actually understood the problem. A CocoaPods-installed version of this library will _never_ compile unless you include my changes.

The extras dir _cannot_ be omitted, because the QuickDialog/QuickDialog.h includes an import of QuickPickerElement.h, which will not exist in the CocoaPods derived project at all if you do not include extras (or at least that file).

Further, even if you'd rather fix the issue by removing that line from the QuickDialog.h file, you still need to add the MapKit and CoreLocation frameworks.
