### PR TITLE
Feature: Search & Swipe to Delete

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'QuickDialog'
-  s.version  = '0.9.1'
+  s.version  = '0.9.2'
   s.platform = :ios, '5.0'
   s.license  = 'Apache License, Version 2.0'
   s.summary  = 'Quick and easy dialog screens for iOS.'

--- a/quickdialog.xcworkspace/xcshareddata/quickdialog.xccheckout
+++ b/quickdialog.xcworkspace/xcshareddata/quickdialog.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>C2ADC056-BB29-4A9E-BFF7-4A55737C4F67</string>
+	<key>IDESourceControlProjectName</key>
+	<string>quickdialog</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>286EDB20-05DD-4445-B123-DD8914259C80</key>
+		<string>ssh://github.com/Nub/QuickDialog.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>quickdialog.xcworkspace</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>286EDB20-05DD-4445-B123-DD8914259C80</key>
+		<string>..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>ssh://github.com/Nub/QuickDialog.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>110</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>286EDB20-05DD-4445-B123-DD8914259C80</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>286EDB20-05DD-4445-B123-DD8914259C80</string>
+			<key>IDESourceControlWCCName</key>
+			<string>QuickDialog</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/quickdialog/QSection.h
+++ b/quickdialog/QSection.h
@@ -56,6 +56,15 @@
 @property(nonatomic, assign) BOOL hidden;
 @property(nonatomic, readonly) NSUInteger visibleIndex;
 
+
+/** * Called before a row is deleted to check on ability, and to handle the
+ * disposal of the associated data object.
+ * @property onDeleteRow Callback to perform safety check, and update data @note
+ * The QElement will automatically be deleted by the QSection. If no callback is
+ * provided, then YES is the default return, and no action is taken on the
+ * bound data
+ **/
+@property(nonatomic, copy) BOOL (^onDeleteRow)(QElement* row);
 @property(nonatomic, assign) BOOL canDeleteRows;
 @property(nonatomic, strong) id object;
 
@@ -65,6 +74,9 @@
 - (void)addElement:(QElement *)element;
 - (void)insertElement:(QElement *)element atIndex:(NSUInteger)index;
 - (NSUInteger)indexOfElement:(QElement *)element;
+
+- (BOOL)removeElementForRow:(NSUInteger)integer;
+- (BOOL)canRemoveElementForRow:(NSUInteger)integer;
 
 - (QElement *)getVisibleElementForIndex:(NSInteger)index;
 - (NSInteger)visibleNumberOfElements;

--- a/quickdialog/QSection.h
+++ b/quickdialog/QSection.h
@@ -1,13 +1,13 @@
-//                                
+//
 // Copyright 2011 ESCOZ Inc  - http://escoz.com
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this 
-// file except in compliance with the License. You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed under
-// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 // ANY KIND, either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
@@ -19,12 +19,12 @@
 @class QElement;
 
 @interface QSection : NSObject {
-
+    
     NSString *_key;
     NSString *_bind;
-
+    
     CGRect _entryPosition;
-
+    
 @private
     __unsafe_unretained QRootElement *_rootElement;
     UIView *_headerView;
@@ -64,7 +64,8 @@
  * provided, then YES is the default return, and no action is taken on the
  * bound data
  **/
-@property(nonatomic, copy) BOOL (^onDeleteRow)(QElement* row);
+@property(nonatomic, copy) BOOL (^canDeleteRow)(QElement* row);
+@property(nonatomic, copy) void (^onDeleteRow)(QElement* row);
 @property(nonatomic, assign) BOOL canDeleteRows;
 @property(nonatomic, strong) id object;
 

--- a/quickdialog/QSection.m
+++ b/quickdialog/QSection.m
@@ -137,6 +137,26 @@
     return NSNotFound;
 }
 
+- (BOOL)removeElementForRow:(NSUInteger)index {
+    if (self.canDeleteRows && [self canRemoveElementForRow:index]) {
+        [self.elements removeObjectAtIndex:index];
+        return YES;
+    }
+    return NO;
+}
+
+- (BOOL)canRemoveElementForRow:(NSUInteger)index {
+    BOOL onDeleteRowResponse = YES;
+    
+    if (self.onDeleteRow) {
+        onDeleteRowResponse = self.onDeleteRow(self.elements[index]);
+    }
+    
+    BOOL isInBounds = (index < self.elements.count);
+    
+    return isInBounds && onDeleteRowResponse && self.canDeleteRows;
+}
+
 - (void)fetchValueIntoObject:(id)obj {
     for (QElement *el in elements){
         [el fetchValueIntoObject:obj];

--- a/quickdialog/QSection.m
+++ b/quickdialog/QSection.m
@@ -1,13 +1,13 @@
-//                                
+//
 // Copyright 2011 ESCOZ Inc  - http://escoz.com
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this 
-// file except in compliance with the License. You may obtain a copy of the License at 
-// 
-// http://www.apache.org/licenses/LICENSE-2.0 
-// 
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software distributed under
-// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF 
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 // ANY KIND, either express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
@@ -139,6 +139,9 @@
 
 - (BOOL)removeElementForRow:(NSUInteger)index {
     if (self.canDeleteRows && [self canRemoveElementForRow:index]) {
+        if (self.onDeleteRow) {
+            self.onDeleteRow(self.elements[index]);
+        }
         [self.elements removeObjectAtIndex:index];
         return YES;
     }
@@ -148,8 +151,8 @@
 - (BOOL)canRemoveElementForRow:(NSUInteger)index {
     BOOL onDeleteRowResponse = YES;
     
-    if (self.onDeleteRow) {
-        onDeleteRowResponse = self.onDeleteRow(self.elements[index]);
+    if (self.canDeleteRow) {
+        onDeleteRowResponse = self.canDeleteRow(self.elements[index]);
     }
     
     BOOL isInBounds = (index < self.elements.count);
@@ -171,21 +174,21 @@
 
 - (void)bindToObject:(id)data {
     if ([self.bind length]==0 || [self.bind rangeOfString:@"iterate"].location == NSNotFound)  {
-            for (QElement *el in self.elements) {
-                [el bindToObject:data];
-            }
-        } else {
-            [self.elements removeAllObjects];
+        for (QElement *el in self.elements) {
+            [el bindToObject:data];
         }
-
-        [[QBindingEvaluator new] bindObject:self toData:data];
-
+    } else {
+        [self.elements removeAllObjects];
+    }
+    
+    [[QBindingEvaluator new] bindObject:self toData:data];
+    
 }
 
 - (void)fetchValueUsingBindingsIntoObject:(id)data {
     for (QElement *el in self.elements) {
         [el fetchValueUsingBindingsIntoObject:data];
     }
-
+    
 }
 @end

--- a/quickdialog/QSortingSection.h
+++ b/quickdialog/QSortingSection.h
@@ -29,8 +29,4 @@
 @property(nonatomic, assign) BOOL canDeleteRows;
 
 - (void)moveElementFromRow:(NSUInteger)from toRow:(NSUInteger)to;
-
-- (BOOL)removeElementForRow:(NSInteger)integer;
-
-- (BOOL)canRemoveElementForRow:(NSInteger)integer;
 @end

--- a/quickdialog/QSortingSection.m
+++ b/quickdialog/QSortingSection.m
@@ -51,13 +51,4 @@
     [self.elements moveObjectFromIndex:from toIndex:to];
 }
 
-- (BOOL)removeElementForRow:(NSInteger)index {
-    [self.elements removeObjectAtIndex:(NSUInteger) index];
-    return YES;
-
-}
-
-- (BOOL)canRemoveElementForRow:(NSInteger)integer {
-    return YES;
-}
 @end

--- a/quickdialog/QuickDialogController.h
+++ b/quickdialog/QuickDialogController.h
@@ -38,6 +38,9 @@
 @property(nonatomic, strong) QuickDialogTableView *quickDialogTableView;
 @property(nonatomic) BOOL resizeWhenKeyboardPresented;
 
+@property(nonatomic, readonly) UISearchBar* searchBar;
+@property(nonatomic) BOOL searchable;
+
 
 @property(nonatomic, strong) UIPopoverController *popoverBeingPresented;
 @property(nonatomic, strong) UIPopoverController *popoverForChildRoot;

--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -231,6 +231,9 @@
        }
     }
     [self.quickDialogTableView reloadData];
+    //Reload sections
+    [self.quickDialogTableView beginUpdates];
+    [self.quickDialogTableView endUpdates];
     self.searchBar.text = nil;
 }
 
@@ -238,11 +241,15 @@
     NSPredicate* searchPredicate = [NSPredicate predicateWithFormat:@"SELF.title CONTAINS[cd] %@", searchText];
     for (QSection* section in self.root.sections) {
         if ([searchPredicate evaluateWithObject:section]) {
+            section.hidden = NO;
         }
         else {
+            section.hidden = YES;
+            
             for (QElement* element in section.elements) {
                 if ([searchPredicate evaluateWithObject:element]) {
                     element.hidden = NO;
+                    section.hidden = NO;
                 }
                 else {
                     element.hidden = YES;
@@ -251,6 +258,9 @@
         }
     }
     [self.quickDialogTableView reloadData];
+    //Reload sections
+    [self.quickDialogTableView beginUpdates];
+    [self.quickDialogTableView endUpdates];
 }
 
 @end

--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -205,19 +205,15 @@
     _searchable = searchable;
     
     if (searchable) {
+        if (!self.searchBar) {
+            self.searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44)];
+            self.searchBar.delegate = self;
+        }
         self.quickDialogTableView.tableHeaderView = self.searchBar;
     } else {
         self.quickDialogTableView.tableHeaderView = nil;
         [self clearSearch];
     }
-}
-
-- (UISearchBar *)searchBar {
-    if (!_searchBar) {
-        _searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 44)];
-        _searchBar.delegate = self;
-    }
-    return _searchBar;
 }
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
@@ -235,10 +231,11 @@
        }
     }
     [self.quickDialogTableView reloadData];
+    self.searchBar.text = nil;
 }
 
 - (void)search:(NSString*)searchText {
-    NSPredicate* searchPredicate = [NSPredicate predicateWithFormat:@"self.title CONTAINS[cd] %@", searchText];
+    NSPredicate* searchPredicate = [NSPredicate predicateWithFormat:@"SELF.title CONTAINS[cd] %@", searchText];
     for (QSection* section in self.root.sections) {
         if ([searchPredicate evaluateWithObject:section]) {
         }

--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -69,8 +69,8 @@
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
     QSection  *section = [_tableView.root getVisibleSectionForIndex: indexPath.section];
-    if ([section isKindOfClass:[QSortingSection class]]){
-        return ([(QSortingSection *) section canRemoveElementForRow:indexPath.row]);
+    if (section.canDeleteRows){
+        return ([section canRemoveElementForRow:indexPath.row]);
     }
     return tableView.editing;
 }

--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -68,7 +68,7 @@
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
-    QSection  *section = [_tableView.root getVisibleSectionForIndex: indexPath.section];
+    QSection *section = [_tableView.root getVisibleSectionForIndex: indexPath.section];
     if (section.canDeleteRows){
         return ([section canRemoveElementForRow:indexPath.row]);
     }

--- a/sample/ExampleAppDelegate.m
+++ b/sample/ExampleAppDelegate.m
@@ -26,6 +26,7 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     QRootElement *root = [SampleDataBuilder create];
     ExampleViewController *quickformController = (ExampleViewController *) [[ExampleViewController alloc] initWithRoot:root];
+    quickformController.searchable = YES;
     UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:quickformController];
     if ([UIDevice currentDevice].userInterfaceIdiom==UIUserInterfaceIdiomPhone) {
         self.window.rootViewController = nav;

--- a/sample/ExampleViewController.m
+++ b/sample/ExampleViewController.m
@@ -82,4 +82,9 @@
     }
 
 }
+
+- (void)toggleSearchable:(QBooleanElement*)searchToggle {
+    self.searchable = searchToggle.boolValue;
+}
+
 @end

--- a/sample/Resources/jsondatasample.json
+++ b/sample/Resources/jsondatasample.json
@@ -14,15 +14,15 @@
                 { "type":"QRadioElement", "title":"Radio", "selected":0, "bind":"selectedValue:radio", "items":["item 1", "item 2", "item 3"]}
 			]
 		},
-		{
-                 "canDeleteRows":true,
-                 "elements":[
+		{ "elements":[
                 { "type":"QButtonElement", "key":"bt1", "title":"Set values directly", "controllerAction":"handleSetValuesDirectly:"},
                 { "type":"QButtonElement", "key":"bt2", "title":"Bind to Object", "controllerAction":"handleBindToObject:"} ,
                 { "type":"QButtonElement", "key":"bt2", "title":"Load JSON with Object", "controllerAction":"handleLoadJsonWithDict:"},
                 { "type":"QButtonElement", "key":"bt3", "title":"Load JSON", "controllerAction":"handleReloadJson:"},
                 { "type":"QButtonElement", "key":"bt4", "title":"Read Values from Form", "controllerAction":"readValuesFromForm:"},
                 { "type":"QButtonElement", "key":"bt5", "title":"Disabled Button","enabled":false}
+
+
 			]
 		}
 	]

--- a/sample/Resources/jsondatasample.json
+++ b/sample/Resources/jsondatasample.json
@@ -14,15 +14,15 @@
                 { "type":"QRadioElement", "title":"Radio", "selected":0, "bind":"selectedValue:radio", "items":["item 1", "item 2", "item 3"]}
 			]
 		},
-		{ "elements":[
+		{
+                 "canDeleteRows":true,
+                 "elements":[
                 { "type":"QButtonElement", "key":"bt1", "title":"Set values directly", "controllerAction":"handleSetValuesDirectly:"},
                 { "type":"QButtonElement", "key":"bt2", "title":"Bind to Object", "controllerAction":"handleBindToObject:"} ,
                 { "type":"QButtonElement", "key":"bt2", "title":"Load JSON with Object", "controllerAction":"handleLoadJsonWithDict:"},
                 { "type":"QButtonElement", "key":"bt3", "title":"Load JSON", "controllerAction":"handleReloadJson:"},
                 { "type":"QButtonElement", "key":"bt4", "title":"Read Values from Form", "controllerAction":"readValuesFromForm:"},
                 { "type":"QButtonElement", "key":"bt5", "title":"Disabled Button","enabled":false}
-
-
 			]
 		}
 	]

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -81,7 +81,7 @@
     subForm.controllerName = @"ExampleViewController";
     QSection *subsection = [[QSection alloc] initWithTitle:@"Long title for the long list of elements"];
     subsection.canDeleteRows = YES;
-    subsection.onDeleteRow = ^(QElement* element){
+    subsection.canDeleteRow = ^BOOL (QElement* element){
         if (element.visibleIndex % 2) {
             return NO;
         }

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -730,6 +730,9 @@
 	QSection *sectionSamples = [[QSection alloc] init];
     sectionSamples.footer = @"Hey there, this is a footer.";
     sectionSamples.headerView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"quickdialog"]];
+    QBooleanElement* searchToggle = [[QBooleanElement alloc] initWithTitle:@"Searchable" BoolValue:YES];
+    searchToggle.controllerAction = @"toggleSearchable:";
+    [sectionSamples addElement:searchToggle];
     [sectionSamples addElement:[[QRootElement alloc] initWithJSONFile:@"loginform"]];
     [sectionSamples addElement:[self createSampleControls]];
     [sectionSamples addElement:[self createSampleFormRoot]];

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -82,7 +82,7 @@
     QSection *subsection = [[QSection alloc] initWithTitle:@"Long title for the long list of elements"];
     subsection.canDeleteRows = YES;
     subsection.onDeleteRow = ^(QElement* element){
-        if (element.visibleIndex % 3) {
+        if (element.visibleIndex % 2) {
             return NO;
         }
         return YES;

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -80,6 +80,13 @@
     subForm.title = @"Really long list";
     subForm.controllerName = @"ExampleViewController";
     QSection *subsection = [[QSection alloc] initWithTitle:@"Long title for the long list of elements"];
+    subsection.canDeleteRows = YES;
+    subsection.onDeleteRow = ^(QElement* element){
+        if (element.visibleIndex % 3) {
+            return NO;
+        }
+        return YES;
+    };
     for (int i = 0; i<1000; i++){
         QBooleanElement *bool1 = [[QBooleanElement alloc] initWithTitle:[NSString stringWithFormat:@"Option %d", i] BoolValue:(i % 3 == 0)];
         bool1.onImage = [UIImage imageNamed:@"imgOn"];


### PR DESCRIPTION
Hey guys, thought I'd share some of my modifications.
## Search

I added the ability to search/filter items automatically by simply toggling the `searchable` flag on `QuickDialogController`. I saw there was another pull request that implemented searching, however it was mentioned that it should be included as automatic searching. This current implementation searches titles only, expanding it to search other values would require me to dig at custom elements a bit more. So here is my basic implementation.
## Delete

Hey guys, I saw there was some deleting capabilities in the sortable sections, however I also saw `canDeleteRows` living in `QSortingSection`, so I migrated the deletion logic up to `QSection`, and added an `onDeleteRow` and `canDeleteRow` callbacks to manage deletions and per row enable/disabling of deletion.

Merged in branch F-SwipeDelete.
