### PR TITLE
QTableViewCell sizeWithMargin properly calculates margin

### DIFF
--- a/quickdialog/QTableViewCell.m
+++ b/quickdialog/QTableViewCell.m
@@ -15,8 +15,8 @@
 #import "QTableViewCell.h"
 @implementation QTableViewCell
 
-static const int kCellMarginDouble = 16;
-static const int kCellMargin = 8;
+static const int kCellMarginDouble = 20;
+static const int kCellMargin = 10;
 static const int kCellMinimumLabelWidth = 40;
 
 


### PR DESCRIPTION
Here are some highlighted before and after shots;

Before:
![ios simulator screen shot 23 sep 2013 18 24 50](https://f.cloud.github.com/assets/58052/1193089/5106d1b0-246d-11e3-941a-8819cc5df2e5.png)
![ios simulator screen shot 23 sep 2013 18 24 52](https://f.cloud.github.com/assets/58052/1193091/54b11a3c-246d-11e3-83bd-79a2fcf34bb4.png)

After:
![ios simulator screen shot 23 sep 2013 18 26 14](https://f.cloud.github.com/assets/58052/1193095/5f664966-246d-11e3-98fa-fc87c555bbf5.png)
![ios simulator screen shot 23 sep 2013 18 26 18](https://f.cloud.github.com/assets/58052/1193096/62c7a24e-246d-11e3-9517-c121bf89b82b.png)

Should resolve issue #545
