### PR TITLE
Add missing webview import

### DIFF
--- a/extras/QWebElement.m
+++ b/extras/QWebElement.m
@@ -14,6 +14,8 @@
 
 #import "QWebElement.h"
 #import "QuickDialog.h"
+#import "QWebViewController.h"
+
 @implementation QWebElement
 
 @synthesize url = _url;


### PR DESCRIPTION
Build is broken as of https://github.com/escoz/QuickDialog/commit/32b58d261c94e4c2208a8218e1738850a89d0694.

This pull adds the missing `#import "QWebViewController.h"`
