### PR TITLE
Import QWebViewController explicitly

### DIFF
--- a/extras/QWebElement.m
+++ b/extras/QWebElement.m
@@ -14,6 +14,7 @@
 
 #import "QWebElement.h"
 #import "QuickDialog.h"
+#import "QWebViewController.h"
 @implementation QWebElement
 
 @synthesize url = _url;


### PR DESCRIPTION
QWebElement needs to import QWebViewController (extra) as QuickDialog.h doesn't have it imported.
