### PR TITLE
Object independent Radio Elements

### DIFF
--- a/QuickDialog.xcodeproj/project.pbxproj
+++ b/QuickDialog.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A0D12E31836DCA9008FA6FC /* SportObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A0D12E21836DCA9008FA6FC /* SportObject.m */; };
 		194C3FC214EDF0510036C9E7 /* DOAutocompleteTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 194C3FC014EDF0510036C9E7 /* DOAutocompleteTextField.h */; };
 		194C3FC314EDF0510036C9E7 /* DOAutocompleteTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = 194C3FC114EDF0510036C9E7 /* DOAutocompleteTextField.m */; };
 		2C542394145ADEBD0026A152 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D80B0E3913E052DF00FA85CA /* Foundation.framework */; };
@@ -190,6 +191,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A0D12E11836DCA9008FA6FC /* SportObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SportObject.h; path = sample/SportObject.h; sourceTree = SOURCE_ROOT; };
+		0A0D12E21836DCA9008FA6FC /* SportObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SportObject.m; path = sample/SportObject.m; sourceTree = SOURCE_ROOT; };
 		194C3FC014EDF0510036C9E7 /* DOAutocompleteTextField.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DOAutocompleteTextField.h; path = quickdialog/DOAutocompleteTextField.h; sourceTree = SOURCE_ROOT; };
 		194C3FC114EDF0510036C9E7 /* DOAutocompleteTextField.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DOAutocompleteTextField.m; path = quickdialog/DOAutocompleteTextField.m; sourceTree = SOURCE_ROOT; };
 		2C542393145ADEBD0026A152 /* libQuickDialog.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libQuickDialog.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -511,6 +514,8 @@
 				F209CEE31536AB100043F61C /* PeriodPickerValueParser.m */,
 				D811F8EF13EC907200E3922B /* Resources */,
 				D80B0E3E13E052DF00FA85CA /* Supporting Files */,
+				0A0D12E11836DCA9008FA6FC /* SportObject.h */,
+				0A0D12E21836DCA9008FA6FC /* SportObject.m */,
 			);
 			name = sample;
 			path = quickformexample;
@@ -962,6 +967,7 @@
 				D8F180E813F0599A009B0CAC /* JsonDataSampleController.m in Sources */,
 				F209CEE41536AB100043F61C /* PeriodPickerValueParser.m in Sources */,
 				5C50EB6A5469607BDA08A4F0 /* QWebViewController.m in Sources */,
+				0A0D12E31836DCA9008FA6FC /* SportObject.m in Sources */,
 				5C50E18E8FEC2BCC8B8C12EA /* QMapAnnotation.m in Sources */,
 				5C50E7FD1C54757459D8F88B /* QPickerTableViewCell.m in Sources */,
 				5C50E2B67E1D64DAE87FD81D /* QPickerTabDelimitedStringParser.m in Sources */,

--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -55,7 +55,7 @@
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {
     QTableViewCell *cell = (QTableViewCell *) [super getCellForTableView:tableView controller:controller];
     cell.selectionStyle = UITableViewCellSelectionStyleNone;
-    cell.textLabel.text = _title;
+    cell.textLabel.text = [_title description];
     cell.detailTextLabel.text = [_value description];
     cell.imageView.image = _image;
     cell.accessoryType = _accessoryType != UITableViewCellAccessoryNone ? _accessoryType : self.controllerAccessoryAction != nil ? UITableViewCellAccessoryDetailDisclosureButton : ( self.sections!= nil || self.controllerAction!=nil ? UITableViewCellAccessoryDisclosureIndicator : UITableViewCellAccessoryNone);

--- a/quickdialog/QRadioElement.h
+++ b/quickdialog/QRadioElement.h
@@ -30,6 +30,7 @@
 @property(nonatomic, assign, readwrite) NSInteger selected;
 @property(nonatomic, retain) NSArray *values;
 @property(nonatomic, strong) NSArray *itemsImageNames;
+@property(nonatomic) SEL action;
 
 - (QRadioElement *)initWithDict:(NSDictionary *)valuesDictionary selected:(int)selected title:(NSString *)title;
 

--- a/quickdialog/QRadioElement.m
+++ b/quickdialog/QRadioElement.m
@@ -24,6 +24,7 @@
 @synthesize values = _values;
 @synthesize items = _items;
 @synthesize itemsImageNames = _itemsImageNames;
+@synthesize action = _action;
 
 
 - (void)createElements {
@@ -169,7 +170,12 @@
     if (_selected < 0 || _selected >= (_values != nil ? _values : _items).count)
         return;
 
-    if (_values==nil){
+    if (_action) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [obj setValue:[self.selectedItem performSelector:_action] forKey:_key];
+#pragma clang diagnostic pop
+    } else if (_values==nil){
         [obj setValue:[NSNumber numberWithInt:_selected] forKey:_key];
     } else {
         [obj setValue:[_values objectAtIndex:(NSUInteger) _selected] forKey:_key];

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -20,6 +20,7 @@
 #import "QWebElement.h"
 #import "QMailElement.h"
 #import "QPickerElement.h"
+#import "SportObject.h"
 
 @implementation SampleDataBuilder
 
@@ -291,6 +292,24 @@
     QSection *section1 = [[QSection alloc] initWithTitle:@"Radio element with push"];
     [section1 addElement:[[QRadioElement alloc] initWithItems:[NSArray arrayWithObjects:@"Football", @"Soccer", @"Formula 1", nil] selected:0]];
     [section1 addElement:[[QRadioElement alloc] initWithItems:[NSArray arrayWithObjects:@"Football", @"Soccer", @"Formula 1", nil] selected:0 title:@"Sport"]];
+    
+    //Add array of objects that respond to description
+    NSArray *sportObjects = [NSArray arrayWithObjects:
+                             [[SportObject alloc] initWithName:@"Football" andId:1],
+                             [[SportObject alloc] initWithName:@"Soccer" andId:2],
+                             [[SportObject alloc] initWithName:@"Formula 1" andId:3],
+                             nil
+                             ];
+    
+    QRadioElement *sportObjectsElement = [[QRadioElement alloc] initWithItems:sportObjects
+                                                                     selected:0
+                                                                        title:@"Sport Objects"];
+    
+    //Optional if you want the fetched value to be different than the [object description] add action selector
+    [sportObjectsElement setAction:@selector(sportId)];
+    [section1 addElement:sportObjectsElement];
+    
+    
     [section1 addElement:[[QRadioElement alloc] initWithDict:[NSDictionary dictionaryWithObjectsAndKeys:@"FerrariObj", @"Ferrari", @"McLarenObj", @"McLaren", @"MercedesObj", @"Mercedes", nil] selected:0 title:@"With Dict"]];
 
     QRadioElement *elementWithAction = [[QRadioElement alloc] initWithItems:[NSArray arrayWithObjects:@"Ferrari", @"McLaren", @"Lotus", nil] selected:0 title:@"WithAction"];

--- a/sample/SportObject.h
+++ b/sample/SportObject.h
@@ -1,0 +1,18 @@
+//
+//  SportObject.h
+//  QuickDialog
+//
+//  Created by Petar Sokarovski on 11/15/13.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SportObject : NSObject
+
+@property (nonatomic, retain) NSString *sportName;
+@property (nonatomic) int sportId;
+
+- (id)initWithName:(NSString *)name andId:(int)sportId;
+
+@end

--- a/sample/SportObject.m
+++ b/sample/SportObject.m
@@ -1,0 +1,28 @@
+//
+//  SportObject.m
+//  QuickDialog
+//
+//  Created by Petar Sokarovski on 11/15/13.
+//
+//
+
+#import "SportObject.h"
+
+@implementation SportObject
+
+@synthesize sportName = _sportName;
+@synthesize sportId = _sportId;
+
+- (id)initWithName:(NSString *)name andId:(int)sportId {
+    if (self = [super init]) {
+        _sportName = name;
+        _sportId = sportId;
+    }
+    return self;
+}
+
+- (NSString *)description {
+    return _sportName;
+}
+
+@end


### PR DESCRIPTION
Allow Quick Radio Elements to work with any objects that responds to “description” selector instead of using Strings only. And also allow the fetched value to be determined by a selector called action instead of always returning the string. Maybe this can be replaced with block i am not sure of that...
