### PR TITLE
Not including extras by default. Also added subspecs to selectively include extra components

### DIFF
--- a/QuickDialog.podspec
+++ b/QuickDialog.podspec
@@ -13,11 +13,31 @@ Pod::Spec.new do |s|
                    'and efficient, you can create forms with multiple text fields, or with ' \
                    'thousands of items with no sweat!'
 
-  s.source_files = 'quickdialog', '*.{h,m}'
   s.requires_arc = true
+  s.default_subspec = "Core"
+
+  s.subspec "Core" do |sp|
+    sp.source_files = 'quickdialog', '*.{h,m}'
+  end
 
   s.subspec "Extras" do |sp|
     sp.source_files = 'extras', '*.{h,m}'
+  end
+
+  s.subspec "QPicker" do |sp|
+    sp.source_files = 'extras/QPicker*.{h,m}'
+  end
+  s.subspec "QMail" do |sp|
+    sp.source_files = 'extras/QMail*.{h,m}'
+  end
+  s.subspec "QMap" do |sp|
+    sp.source_files = 'extras/QMap*.{h,m}'
+  end
+  s.subspec "QWeb" do |sp|
+    sp.source_files = 'extras/QWeb*.{h,m}'
+  end
+  s.subspec "QColor" do |sp|
+    sp.source_files = 'extras/QColor*.{h,m}', 'extras/UIColor*.{h,m}'
   end
 
   s.prefix_header_contents = <<-EOS


### PR DESCRIPTION
pod 'QuickDialog' will now only include the 'core' elements

pod 'QuickDialog/Core’ will include the core elements
pod 'QuickDialog/Extras' will include all extras
pod 'QuickDialog/QPicker' will only include the QPicker extras
... etc...
