### PR TITLE
Added support to QPickerElement for submit values

### DIFF
--- a/extras/QPickerElement.h
+++ b/extras/QPickerElement.h
@@ -11,11 +11,17 @@
 @property (nonatomic, strong) id<QPickerValueParser> valueParser;
 
 @property (nonatomic, strong) NSArray *items;
+@property (nonatomic, strong) NSArray *itemsValues;
 @property (nonatomic, readonly) NSArray *selectedIndexes;
 
+@property (nonatomic, strong) id displayValue;
+@property (nonatomic, strong) id submitValue;
+
 - (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items value:(id)value;
+- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items itemsValues:(NSArray *) itemsValues value:(id)value;
 
 - (void)reloadAllComponents;
 - (void)reloadComponent:(NSInteger)index;
+
 
 @end

--- a/extras/QPickerElement.m
+++ b/extras/QPickerElement.m
@@ -6,11 +6,13 @@
 {
 @private
     NSArray *_items;
-    
+    NSArray *_itemsValues;
     UIPickerView *_pickerView;
+
 }
 
 @synthesize items = _items;
+@synthesize itemsValues = _itemsValues;
 @synthesize valueParser = _valueParser;
 
 - (QPickerElement *)init
@@ -26,6 +28,15 @@
 {
     if ((self = [super initWithTitle:title Value:value])) {
         _items = items;
+        self.valueParser = [QPickerTabDelimitedStringParser new];
+    }
+    return self;
+}
+- (QPickerElement *)initWithTitle:(NSString *)title items:(NSArray *)items itemsValues:(NSArray *)itemsValues value:(id)value
+{
+    if ((self = [super initWithTitle:title Value:value])) {
+        _items = items;
+        _itemsValues = itemsValues;
         self.valueParser = [QPickerTabDelimitedStringParser new];
     }
     return self;
@@ -51,7 +62,7 @@
 - (void)fetchValueIntoObject:(id)obj
 {
 	if (_key != nil) {
-        [obj setValue:_value forKey:_key];
+        [obj setValue:_submitValue forKey:_key];
     }
 }
 

--- a/extras/QPickerTableViewCell.m
+++ b/extras/QPickerTableViewCell.m
@@ -110,14 +110,15 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
 
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-    self.pickerElement.value = [self getPickerViewValue];
+    self.pickerElement.value = self.pickerElement.displayValue = [self getPickerViewValue:false];
+    self.pickerElement.submitValue = [self getPickerViewValue:true];
     [self prepareForElement:_entryElement inTableView:_quickformTableView];
     [self.pickerElement handleEditingChanged];
 }
 
 #pragma mark - Getting/setting value from UIPickerView
 
-- (id)getPickerViewValue
+- (id)getPickerViewValue:(BOOL)submitValue
 {
     NSMutableArray *componentsValues = [NSMutableArray array];
     
@@ -125,7 +126,10 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
     {
         NSInteger rowIndex = [_pickerView selectedRowInComponent:i];
         if (rowIndex >= 0) {
-            [componentsValues addObject:[self pickerView:_pickerView titleForRow:rowIndex forComponent:i]];
+            if (self.pickerElement.itemsValues == nil || !submitValue)
+                [componentsValues addObject:[self pickerView:_pickerView titleForRow:rowIndex forComponent:i]];
+            else
+                [componentsValues addObject:[self.pickerElement.itemsValues[i] objectAtIndex:rowIndex]];
         } else {
             [componentsValues addObject:[NSNull null]];
         }
@@ -135,6 +139,8 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
     return [self.pickerElement.valueParser objectFromComponentsValues:componentsValues];
 }
 
+
+
 - (void)setPickerViewValue:(id)value
 {
     NSArray *componentsValues = [self.pickerElement.valueParser componentsValuesFromObject:value];
@@ -142,7 +148,16 @@ NSString * const QPickerTableViewCellIdentifier = @"QPickerTableViewCell";
     for (int componentIndex = 0; componentIndex < componentsValues.count && componentIndex < _pickerView.numberOfComponents; componentIndex++)
     {
         id componentValue = [componentsValues objectAtIndex:(NSUInteger) componentIndex];
-        NSInteger rowIndex = [[self.pickerElement.items objectAtIndex:componentIndex] indexOfObject:componentValue];
+        NSInteger rowIndex = NSNotFound;
+//        if (self.pickerElement.itemsValues == nil)
+//        {
+            rowIndex = [[self.pickerElement.items objectAtIndex:componentIndex] indexOfObject:componentValue];
+//        }
+//        else
+//        {
+//            rowIndex = [[self.pickerElement.itemsValues objectAtIndex:componentIndex] indexOfObject:componentValue];
+//        }
+        
         if (rowIndex != NSNotFound) {
             [_pickerView selectRow:rowIndex inComponent:componentIndex animated:YES];
         }


### PR DESCRIPTION
Now it is possible to use submit values:

```
NSArray *component1 = @[@"Vendita", @"Affitto", @"Vacanza"];
NSArray *componentValues1 = @[@"V", @"A", @"S"];
NSArray *component2 = @[@"A", @"B"];
NSArray *componentValues2 = @[@"aaaa", @"bbbbb"];
QPickerElement *simplePickerEl = [[QPickerElement alloc] initWithTitle:@"Key"
                                                                 items:@[component1, component2]
                                                           itemsValues:@[componentValues1, componentValues2]
                                                                 value:@"Vacanza\tB"];
```

Submit value is obtainable by calling 

simplePickerEl.submitValue
