### PR TITLE
Improve us of images in QRadioElement

### DIFF
--- a/quickdialog/QRadioElement.m
+++ b/quickdialog/QRadioElement.m
@@ -47,6 +47,13 @@
     [self createElements];
 }
 
+-(void)setItemsImageNames:(NSArray *)itemsImageNames {
+    _itemsImageNames = itemsImageNames;
+    if (self.items) {
+        [self createElements];
+    }
+}
+
 -(NSObject *)selectedValue {
     if (_selected<0 || _selected>=_values.count)
         return nil;

--- a/quickdialog/QRadioItemElement.m
+++ b/quickdialog/QRadioItemElement.m
@@ -40,6 +40,7 @@
     cell.accessoryType = selectedIndex == _index ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
     cell.textLabel.textAlignment = NSTextAlignmentLeft; // hardcoded so that appearance doesn't change it
     cell.textLabel.textColor = self.enabled ? self.appearance.valueColorEnabled : self.appearance.valueColorDisabled;
+    cell.imageView.image = self.image;
     return cell;
 }
 

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -162,6 +162,7 @@
 
 
     QRadioElement *radioElement = [[QRadioElement alloc] initWithItems:[[NSArray alloc] initWithObjects:@"Option 1", @"Option 2", @"Option 3",@"Option 11", @"Option 12", @"Option 13", @"Option 21", @"Option 22", @"Option 33", @"Option 41", @"Option 42", @"Option 43", @"Option 51", @"Option 52", @"Option 53", @"Option 61", @"Option 62", @"Option 63", @"Option 71", @"Option 72", @"Option 73", nil] selected:7 title:@"Radio"];
+    radioElement.itemsImageNames = @[ @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel", @"iPhone", @"intel" ];
 	radioElement.key = @"radio1";
 
 


### PR DESCRIPTION
If setting images for items in QRadioElement, display them in QRadioItemElement.

The behavior before that was to display the image on the QRadioElement once one item was selected.
