### PR TITLE
accessory view bug fixed.

### DIFF
--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -150,7 +150,7 @@
 
     if (_entryElement.hiddenToolbar){
         _textField.inputAccessoryView = nil;
-    } else if (_textField==nil){
+    } else if (_textField!=nil){
         UIToolbar *toolbar = [self createActionBar];
         toolbar.barStyle = element.appearance.toolbarStyle;
         toolbar.translucent = element.appearance.toolbarTranslucent;


### PR DESCRIPTION
Prepare for element was trying to add accessory view to text field only when text field is nil.
