### PR TITLE
imageNamed:nil reports log error in xcode 5

### DIFF
--- a/quickdialog/QBooleanElement.m
+++ b/quickdialog/QBooleanElement.m
@@ -45,11 +45,15 @@
 }
 
 - (void)setOnImageName:(NSString *)name {
-    self.onImage = [UIImage imageNamed:name];
+    if(name != nil) {
+        self.onImage = [UIImage imageNamed:name];
+    }
 }
 
 - (void)setOffImageName:(NSString *)name {
-    self.offImage = [UIImage imageNamed:name];
+    if(name != nil) {
+        self.offImage = [UIImage imageNamed:name];
+    }
 }
 
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {

--- a/quickdialog/QImageElement.m
+++ b/quickdialog/QImageElement.m
@@ -54,8 +54,10 @@
 }
 
 - (void)setImageValueNamed:(NSString *)name {
-    self.imageValue = [UIImage imageNamed:name];
-    [self reducedImageIfNeeded];
+    if(name != nil) {
+        self.imageValue = [UIImage imageNamed:name];
+        [self reducedImageIfNeeded];
+    }
 }
 
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller {

--- a/quickdialog/QLabelElement.m
+++ b/quickdialog/QLabelElement.m
@@ -36,7 +36,9 @@
 }
 
 -(void)setImageNamed:(NSString *)name {
-    self.image = [UIImage imageNamed:name];
+    if(name != nil) {
+        self.image = [UIImage imageNamed:name];
+    }
 }
 
 - (NSString *)imageNamed {
@@ -45,7 +47,7 @@
 
 -(void)setIconNamed:(NSString *)name {
 #if __IPHONE_7_0
-    if ([self.image respondsToSelector:@selector(imageWithRenderingMode:)]) {
+    if ([self.image respondsToSelector:@selector(imageWithRenderingMode:)] && name != nil) {
         self.image = [[UIImage imageNamed:name] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     }
 #endif

--- a/quickdialog/QRadioElement.m
+++ b/quickdialog/QRadioElement.m
@@ -164,7 +164,10 @@
     _selected = aSelected;
 
     self.preselectedElementIndex = [NSIndexPath indexPathForRow:_selected inSection:0];
-    self.image = [UIImage imageNamed:[_itemsImageNames objectAtIndex:(NSUInteger) self.selected]];
+
+    if([_itemsImageNames objectAtIndex:(NSUInteger) self.selected] != nil) {
+        self.image = [UIImage imageNamed:[_itemsImageNames objectAtIndex:(NSUInteger) self.selected]];
+    }
     
     [self handleEditingChanged];
 }

--- a/quickdialog/QSelectItemElement.m
+++ b/quickdialog/QSelectItemElement.m
@@ -25,7 +25,9 @@
 }
 
 -(void)setCheckmarkImageNamed:(NSString *)name {
-    self.checkmarkImage = [UIImage imageNamed:name];
+    if(name != nil) {
+        self.checkmarkImage = [UIImage imageNamed:name];
+    }
 }
 
 - (UITableViewCell *)getCellForTableView:(QuickDialogTableView *)tableView controller:(QuickDialogController *)controller


### PR DESCRIPTION
The following was logged each time `[UIImage imageNamed:name];` was called with name = nil.
"CUICatalog: Invalid asset name supplied: (null), or invalid scale factor: 2.000000"

There was no apparent detriment to the app, just to the logging file as it happened 50x per load for my app. I could figure out no way to rectify this short of updating the code to check for nil before requesting named images.
