### PR TITLE
Accessory view segmented control color

### DIFF
--- a/quickdialog/QEntryTableViewCell.m
+++ b/quickdialog/QEntryTableViewCell.m
@@ -36,7 +36,7 @@
     _prevNext = [[UISegmentedControl alloc] initWithItems:[NSArray arrayWithObjects:NSLocalizedString(@"Previous", @""), NSLocalizedString(@"Next", @""), nil]];
     _prevNext.momentary = YES;
     _prevNext.segmentedControlStyle = UISegmentedControlStyleBar;
-    _prevNext.tintColor = actionBar.tintColor;
+    _prevNext.tintColor = [UIToolbar appearance].tintColor;
     [_prevNext addTarget:self action:@selector(handleActionBarPreviousNext:) forControlEvents:UIControlEventValueChanged];
     UIBarButtonItem *prevNextWrapper = [[UIBarButtonItem alloc] initWithCustomView:_prevNext];
     UIBarButtonItem *flexible = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];


### PR DESCRIPTION
Starting from iOS 7.1 SUDDENLY even if u set UIToolBar appearance tint color newly created tool bar tint color will be default and not the one u set using [UIToolbar appearance].tintColor. 

Not sure when is actually applied and are other elements affected, but to apply to prev next segmented control application color theme _prevNext.tintColor should be set from [UIToolbar appearance].tintColor instead of UIToolbar actionBar object tintColor property as it is not set at that moment
