### PR TITLE
Notify QuickDialogController when tableViewCell will be deleted

### DIFF
--- a/quickdialog/QuickDialogController.h
+++ b/quickdialog/QuickDialogController.h
@@ -51,6 +51,11 @@
 
 + (QuickDialogController *)controllerForRoot:(QRootElement *)root;
 
+/**
+ Called before a cell is removed from the tableView.
+*/
+- (void)willDeleteElement:(QElement *)element;
+
 + (UINavigationController *)controllerWithNavigationForRoot:(QRootElement *)root;
 
 

--- a/quickdialog/QuickDialogController.m
+++ b/quickdialog/QuickDialogController.m
@@ -148,6 +148,9 @@
     return [QuickDialogController buildControllerWithClass:controllerClass root:root];
 }
 
+- (void)willDeleteElement:(QElement *)element{
+    // Intentionally empty.
+}
 
 - (void) resizeForKeyboard:(NSNotification*)aNotification {
     if (!_viewOnScreen)

--- a/quickdialog/QuickDialogDataSource.m
+++ b/quickdialog/QuickDialogDataSource.m
@@ -58,6 +58,16 @@
 
 - (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
     QSortingSection *section = ((QSortingSection *) [_tableView.root getVisibleSectionForIndex: indexPath.section]);
+
+    QElement *element;
+    if (section.elements.count >= indexPath.row) {
+        element = section.elements[indexPath.row];
+    }
+
+    if ([element.controller respondsToSelector:@selector(willDeleteElement:)]) {
+        [(QuickDialogController *)element.controller willDeleteElement:element];
+    }
+
     if ([section removeElementForRow:indexPath.row]){
         [tableView deleteRowsAtIndexPaths:[NSArray arrayWithObject:indexPath] withRowAnimation:UITableViewRowAnimationFade];
     }

--- a/sample/ExampleViewController.m
+++ b/sample/ExampleViewController.m
@@ -69,6 +69,10 @@
     }
 }
 
+-(void)willDeleteElement:(QElement *)element{
+    // Optionally you could remove the element from your data source here.
+}
+
 
 -(void)setTheme:(QElement *)element  {
 

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -597,6 +597,7 @@
 
     QSortingSection *sortingSection = [[QSortingSection alloc] init];
     sortingSection.key = @"sortedSection";
+    sortingSection.canDeleteRows = YES;
     [sortingSection addElement:[[QLabelElement alloc] initWithTitle:@"First" Value:@"1"]];
     [sortingSection addElement:[[QLabelElement alloc] initWithTitle:@"Second" Value:@"2"]];
     [sortingSection addElement:[[QLabelElement alloc] initWithTitle:@"Third" Value:@"3"]];


### PR DESCRIPTION
Right now you can swipe to delete if you configure a QSortingSection to allow it, but there's no way for the underlying QuickDialogController to be notified of this event (there's really no way, tried all manner of KVO!).

With this change QuickDialogController will now have a willDeleteElement: method, so data sources can be updated after table cells are deleted.
