### PR TITLE
Fix warnings in Xcode 5

### DIFF
--- a/Classes/Core/QAppearance.h
+++ b/Classes/Core/QAppearance.h
@@ -51,8 +51,8 @@
 @property(nonatomic, strong) UIColor *sectionTitleShadowColor;
 @property(nonatomic) BOOL toolbarTranslucent;
 @property(nonatomic) CGFloat cellBorderWidth;
-@property(nonatomic) NSNumber * defaultHeightForHeader;
-@property(nonatomic) NSNumber * defaultHeightForFooter;
+@property(nonatomic, strong) NSNumber * defaultHeightForHeader;
+@property(nonatomic, strong) NSNumber * defaultHeightForFooter;
 
 @property(nonatomic) UIBarStyle toolbarStyle;
 


### PR DESCRIPTION
The default type of assign throws warnings about assign not being appropriate in Xcode 5.   Furthermore cocoapods :inhibit_warnings => true isn't suppressing these warnings...
