### PR TITLE
Fix: MultilineElment text value  won't update

### DIFF
--- a/quickdialog/QMultilineElement.m
+++ b/quickdialog/QMultilineElement.m
@@ -22,7 +22,7 @@
 - (QEntryElement *)init {
     self = [super init];
     if (self) {
-        self.presentationMode = QPresentationModePopover;
+    	self.presentationMode = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)?QPresentationModeModalForm:QPresentationModePopover;
     }
 
     return self;
@@ -32,7 +32,7 @@
 {
     if ((self = [super initWithTitle:title Value:nil])) {
         self.textValue = text;
-        self.presentationMode = QPresentationModePopover;
+        self.presentationMode = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone)?QPresentationModeModalForm:QPresentationModePopover;
     }
     return self;
 }


### PR DESCRIPTION
Fix: MultilineElment text value  won't update in iPhone.

Issue:
1, Start the sample with iPhone(device or simulator), go to "Sample Controls" -> "Multiline".
2, Type some words and back.

Expected:
The label right to "Multiline" should show some of words typed in the step 2.

Actually:
There is nothing updated, the label in the right is blank.

This issue repro in iPhone, not in iPad.
