### PR TITLE
Added ability to set timezone on inline date picker

### DIFF
--- a/QDateInlineTableViewCell.m
+++ b/QDateInlineTableViewCell.m
@@ -37,7 +37,7 @@
     if (!self.pickerView)
         self.pickerView = [[UIDatePicker alloc] init];
 
-    self.pickerView.timeZone = [NSTimeZone localTimeZone];
+    self.pickerView.timeZone = element.timeZone ? element.timeZone : [NSTimeZone localTimeZone];
     [self.pickerView sizeToFit];
     self.pickerView.datePickerMode = element.mode;
     self.pickerView.maximumDate = element.maximumDate;
@@ -64,6 +64,7 @@
 - (void)prepareForElement:(QDateTimeInlineElement *)element inTableView:(QuickDialogTableView *)tableView {
 
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.timeZone = element.timeZone ? element.timeZone : [NSTimeZone localTimeZone];
 
     self.element = element;
     if (element.customDateFormat!=nil){

--- a/quickdialog/QDateEntryTableViewCell.m
+++ b/quickdialog/QDateEntryTableViewCell.m
@@ -54,7 +54,7 @@
     if (!_pickerView)
         _pickerView = [[UIDatePicker alloc] init];
 
-    _pickerView.timeZone = [NSTimeZone localTimeZone];
+    _pickerView.timeZone = element.timeZone ? element.timeZone : [NSTimeZone localTimeZone];
     [_pickerView sizeToFit];
     [_pickerView addTarget:self action:@selector(dateChanged:) forControlEvents:UIControlEventValueChanged];
     _pickerView.datePickerMode = element.mode;
@@ -100,6 +100,7 @@
     QDateTimeInlineElement *dateElement = ((QDateTimeInlineElement *) element);
 
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    dateFormatter.timeZone = dateElement.timeZone ? dateElement.timeZone : [NSTimeZone localTimeZone];
 
     if (element.customDateFormat!=nil){
         dateFormatter.dateFormat = element.customDateFormat;

--- a/quickdialog/QDateTimeInlineElement.h
+++ b/quickdialog/QDateTimeInlineElement.h
@@ -38,6 +38,8 @@
 
 @property(nonatomic, strong) NSDate *minimumDate;
 
+@property (nonatomic, strong) NSTimeZone *timeZone;
+
 @property(nonatomic) BOOL showPickerInCell;
 
 - (QDateTimeInlineElement *)initWithDate:(NSDate *)date andMode:(UIDatePickerMode)mode;

--- a/quickdialog/QDateTimeInlineElement.m
+++ b/quickdialog/QDateTimeInlineElement.m
@@ -18,6 +18,7 @@
 @private
     NSDate *_maximumDate;
     NSDate *_minimumDate;
+    NSTimeZone *_timeZone;
 
     __weak QTableViewCell *_cell;
 }
@@ -26,6 +27,7 @@
 @synthesize centerLabel = _centerLabel;
 @synthesize maximumDate = _maximumDate;
 @synthesize minimumDate = _minimumDate;
+@synthesize timeZone = _timeZone;
 @synthesize onValueChanged = _onValueChanged;
 @synthesize minuteInterval = _minuteInterval;
 
@@ -67,6 +69,7 @@
 {
     if (self.mode == UIDatePickerModeDate)   {
         NSCalendar *gregorian = [[NSCalendar alloc]initWithCalendarIdentifier:NSGregorianCalendar];
+        gregorian.timeZone = self.timeZone ? self.timeZone : [NSTimeZone localTimeZone];
         NSDateComponents *dateComponents = [gregorian components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit) fromDate:_dateValue];
         _dateValue = [gregorian dateFromComponents:dateComponents];
     }

--- a/sample/SampleDataBuilder.m
+++ b/sample/SampleDataBuilder.m
@@ -659,6 +659,11 @@
 
     QDateTimeInlineElement *el4 = [[QDateTimeInlineElement alloc] initWithTitle:@"Time only" date:[NSDate date] andMode:UIDatePickerModeTime];
     [section addElement:el4];
+    
+    QDateTimeInlineElement *el5 = [[QDateTimeInlineElement alloc] initWithTitle:@"Time only (UTC)" date:[NSDate date] andMode:UIDatePickerModeTime];
+    el5.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    [section addElement:el5];
+
 
     QDateTimeInlineElement *elDiffTime = [[QDateTimeInlineElement alloc] initWithTitle:@"Different date" date:
             [NSDate dateWithTimeIntervalSinceNow:-36000] andMode:UIDatePickerModeDate];
@@ -672,18 +677,18 @@
     QSection *section2 = [[QSection alloc] init];
     section2.title = @"Push editing";
 
-    QDateTimeElement *el5 = [[QDateTimeElement alloc] initWithTitle:@"Time only" date:[NSDate date]];
-    el5.mode = UIDatePickerModeTime;
-    [section2 addElement:el5];
-
-    QDateTimeElement *el6 = [[QDateTimeElement alloc] initWithTitle:@"Date only" date:[NSDate date]];
-    el6.mode = UIDatePickerModeDate;
+    QDateTimeElement *el6 = [[QDateTimeElement alloc] initWithTitle:@"Time only" date:[NSDate date]];
+    el6.mode = UIDatePickerModeTime;
     [section2 addElement:el6];
 
-    QDateTimeElement *el7 = [[QDateTimeElement alloc] initWithTitle:@"Full Date" date:[NSDate date]];
-    el7.mode = UIDatePickerModeDateAndTime;
-    el7.minuteInterval = 3;
+    QDateTimeElement *el7 = [[QDateTimeElement alloc] initWithTitle:@"Date only" date:[NSDate date]];
+    el7.mode = UIDatePickerModeDate;
     [section2 addElement:el7];
+
+    QDateTimeElement *el8 = [[QDateTimeElement alloc] initWithTitle:@"Full Date" date:[NSDate date]];
+    el8.mode = UIDatePickerModeDateAndTime;
+    el8.minuteInterval = 3;
+    [section2 addElement:el8];
 
     [root addSection:section];
     [root addSection:section2];


### PR DESCRIPTION
Due to complexities of our app, we need to set the timezone on our UIDatePickers to something different from our default timezone. This causes us problems when using QuickDialog. Previously we just changed our default timezone before loading QuickDialog, this led to issues when it was displayed modally on an iPad.

With this change, we don't have to override our default timezone for the app, and can just set the timezone on the date picker. I also added an example to the example project for testing and verification. Let me know if you have any questions.