### PR TITLE
extern QPickerTableViewCellIdentifier

### DIFF
--- a/extras/QPickerTableViewCell.h
+++ b/extras/QPickerTableViewCell.h
@@ -8,7 +8,7 @@
 
 #import "QEntryTableViewCell.h"
 
-NSString * const QPickerTableViewCellIdentifier;
+extern NSString * const QPickerTableViewCellIdentifier;
 
 @interface QPickerTableViewCell : QEntryTableViewCell <UIPickerViewDataSource, UIPickerViewDelegate>
 {


### PR DESCRIPTION
duplicate symbol _QPickerTableViewCellIdentifier in:
    /Users/jakey/Library/Developer/Xcode/DerivedData/D-CARS-cbzrhfwoilkurgcuqqdiqjljojbm/Build/Intermediates/D-CARS.build/Debug-iphoneos/D-CARS.build/Objects-normal/arm64/QPickerTableViewCell.o
    /Users/jakey/Library/Developer/Xcode/DerivedData/D-CARS-cbzrhfwoilkurgcuqqdiqjljojbm/Build/Intermediates/D-CARS.build/Debug-iphoneos/D-CARS.build/Objects-normal/arm64/QPickerElement.o
ld: 1 duplicate symbol for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)