### PR TITLE
[QuickDialogTableView] Set root only after data source and delegate are set

### DIFF
--- a/quickdialog/QuickDialogTableView.m
+++ b/quickdialog/QuickDialogTableView.m
@@ -35,7 +35,6 @@
     self = [super initWithFrame:CGRectMake(0, 0, 0, 0) style:controller.root.grouped ? UITableViewStyleGrouped : UITableViewStylePlain];
     if (self!=nil){
         self.controller = controller;
-        self.root = _controller.root;
         self.deselectRowWhenViewAppears = YES;
 
         self.quickDialogDataSource = [[QuickDialogDataSource alloc] initForTableView:self];
@@ -43,6 +42,8 @@
 
         self.quickDialogTableDelegate = [[QuickDialogTableDelegate alloc] initForTableView:self];
         self.delegate = self.quickDialogTableDelegate;
+
+        self.root = _controller.root;
 
         self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     }


### PR DESCRIPTION
iOS 9 calls `reloadData` less agressively than iOS 8 and earlier. If the root of the table view is set too soon (eg. before the data source is set), `reloadData` may not be called in certain cases, resulting in inconsistencies and inducing crashes.
