### PR TITLE
Fixed incorrect data binding bug

### DIFF
--- a/quickdialog/QBindingEvaluator.m
+++ b/quickdialog/QBindingEvaluator.m
@@ -49,7 +49,7 @@
 
     for (NSString *each in [string componentsSeparatedByString:@","]) {
         NSArray *bindingParams = [each componentsSeparatedByString:@":"];
-
+        if (bindingParams.count < 2) continue;
         NSString *propName = [((NSString *) [bindingParams objectAtIndex:0]) stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
         NSString *valueName = [((NSString *) [bindingParams objectAtIndex:1]) stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 


### PR DESCRIPTION
If user creates incorrect binding, ex.: element.bind = @«someValue» instead of @«numberValue:someValue» and then try to fetch values using [root fetchValueUsingBindingsIntoObject:dict] you’ll get crash.
This fix just skips such invalid binded elements.