### PR TITLE
QPickerTableViewCell initializer should call super

### DIFF
--- a/extras/QPickerTableViewCell.m
+++ b/extras/QPickerTableViewCell.m
@@ -19,7 +19,7 @@
 
 - (QPickerTableViewCell *)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
 {
-    if ((self = [self initWithStyle:style reuseIdentifier:reuseIdentifier]))
+    if ((self = [super initWithStyle:style reuseIdentifier:reuseIdentifier]))
     {
         [self createSubviews];
 		self.selectionStyle = UITableViewCellSelectionStyleBlue;


### PR DESCRIPTION
Initializer for QPickerTableViewCell calls self instead of super, resulting in an infinite loop. This fixes it.