### PR TITLE
Fix table view width issue for iOS 9

### DIFF
--- a/quickdialog/QuickDialogTableView.m
+++ b/quickdialog/QuickDialogTableView.m
@@ -46,6 +46,10 @@
         self.root = _controller.root;
 
         self.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        
+        if([self respondsToSelector:@selector(setCellLayoutMarginsFollowReadableWidth:)]) {
+            self.cellLayoutMarginsFollowReadableWidth = NO;
+        }
     }
     return self;
 }


### PR DESCRIPTION
Fix this issue.
http://stackoverflow.com/questions/32845075/ios-9-uitableview-cells-text-label-not-the-full-width-of-the-uitableview
